### PR TITLE
Adding kano-extras to killed_apps

### DIFF
--- a/kano-updater
+++ b/kano-updater
@@ -183,7 +183,7 @@ if not is_internet():
 else:
     # kill_apps
     kill_apps_list = ['minecraft-pi', 'make-music', 'make-video',
-                      'make-snake']
+                      'make-snake', 'kano-extras']
     for app in kill_apps_list:
         run_cmd('killall -q {}'.format(app))
 


### PR DESCRIPTION
So the extras are terminated before an update.

Fixes https://github.com/KanoComputing/peldins/issues/701
