### PR TITLE
Moving the updater to the new logging system

### DIFF
--- a/bin/kano-updater
+++ b/bin/kano-updater
@@ -17,15 +17,17 @@ if __name__ == '__main__' and __package__ is None:
     if dir_path != '/usr':
         sys.path.insert(0, dir_path)
 
-import kano.logger as logger
+from kano.logging import logger
 from kano.network import is_internet
 from kano_updater.osversion import OSVersion, bump_system_version
 from kano_updater.stages import upgrade_debian, upgrade_python
 from kano_updater.scenarios import PreUpdate, PostUpdate
 from kano_updater.utils import get_dpkg_dict, set_update_status, \
-    expand_rootfs, get_installed_version, reboot, reboot_required
+    expand_rootfs, get_installed_version, reboot, reboot_required, \
+    update_failed
 from kano.utils import zenity_show_progress, run_print_output_error, \
-    kill_child_processes, run_cmd, delete_file, is_gui, get_date_now
+    kill_child_processes, run_cmd, delete_file, is_gui, get_date_now, \
+    run_cmd_log
 
 debug = False
 
@@ -61,20 +63,23 @@ if not (preup.covers_update() and postup.covers_update()):
         kdialog.run()
     sys.exit(title)
 
-logger.write("Upgrading from: {}".format(str(old_version)))
-logger.write("Upgrading to: {}".format(str(new_version)))
+logger.info("Upgrading from: {}".format(str(old_version)))
+logger.info("Upgrading to: {}".format(str(new_version)))
 
 # root check
 user = os.environ['LOGNAME']
 if user != 'root':
     title = 'Error!'
     description = 'kano-updater must be executed with root privileges'
+    logger.error(description)
+
     if is_gui:
         kdialog = kano_dialog.KanoDialog(title, description)
         kdialog.run()
+    else:
+        print description
 
-    logger.write(description, level='error')
-    sys.exit(description)
+    sys.exit(1)
 
 # upgrade python command line
 if len(sys.argv) == 2 and sys.argv[1] == 'python_upgrade':
@@ -90,13 +95,13 @@ if not (len(sys.argv) == 2 and sys.argv[1] in ['-f', '--force']):
         kdialog = kano_dialog.KanoDialog(title, description, {"OK": 0, "CANCEL": -1})
         response = kdialog.run()
         if response != 0:
-            logger.write("Canceled by the user.", level="info")
+            logger.info("Canceled by the user.")
             sys.exit()
     else:
         print description + " [y/n]"
         answer = raw_input().lower()
         if answer != 'y':
-            logger.write("Canceled by the user.", level="info")
+            logger.info("Canceled by the user.")
             sys.exit()
 
 if len(sys.argv) == 2 and sys.argv[1] in ['-d', '--debug']:
@@ -115,9 +120,8 @@ if not is_internet():
         print 'Press any key to continue'
         answer = raw_input()
 
-    logger.write(title, level="warn")
-# do upgrade
-else:
+    logger.warn(title)
+else: # do upgrade
     # kill_apps
     kill_apps_list = ['minecraft-pi', 'make-music', 'make-video',
                       'make-snake', 'kano-extras']
@@ -125,21 +129,28 @@ else:
         run_cmd('killall -q {}'.format(app))
 
     progress_bar = zenity_show_progress("Downloading package lists")
-    run_print_output_error('apt-get -y clean')
-    run_print_output_error('apt-get -y update')
+    run_cmd_log('apt-get -y clean')
+    _, _,  rv = run_cmd_log('apt-get -y update')
     kill_child_processes(progress_bar)
+    if rv != 0:
+        update_failed("Could not download the package lists")
 
     # upgrade kano-updater itself
     progress_bar = zenity_show_progress("Updating the updater itself")
     current_updater_version = get_installed_version('kano-updater')
-    run_cmd('apt-get install -o Dpkg::Options::="--force-confdef" ' +
-            '-o Dpkg::Options::="--force-confold" -y --force-yes kano-updater')
-    new_updater_version = get_installed_version('kano-updater')
+
+    cmd = 'apt-get install -o Dpkg::Options::="--force-confdef" ' + \
+          '-o Dpkg::Options::="--force-confold" -y --force-yes kano-updater'
+    _, _, rv = run_cmd_log(cmd)
     kill_child_processes(progress_bar)
 
+    if rv != 0:
+        update_failed("Couldn't update the updater!")
+
+    new_updater_version = get_installed_version('kano-updater')
     # re-run the updater in case it was updated
     if new_updater_version != current_updater_version and not debug:
-        logger.write("The updater was reinstalled, launching again.")
+        logger.info("The updater was reinstalled, launching again.")
         os.execvp('kano-updater', ['kano-updater', '-f'])
 
     # get app-state before upgrading
@@ -160,8 +171,6 @@ else:
     # refresh desktop
     os.system('kdesk -r')
 
-    #TODO: This shouldn't be done, in case there were some major errors
-    # during the update!
     bump_system_version(new_version, version_file, issue_file)
 
     now = int(time.time())
@@ -221,9 +230,7 @@ else:
     if not msg:
         msg = "No updates needed this time."
 
-    # write error log
-    for line in msg.split("\n"):
-        logger.write(line)
+    logger.info(msg)
 
     if is_gui:
         with open('msg', 'w') as outfile:
@@ -244,9 +251,8 @@ else:
 
 # expand filesystem
 will_expand = expand_rootfs()
-
 if will_expand or reboot_required(require_restart, pkgs_changed):
     title = "Your computer needs to restart"
     description = "Then it will be able to use all the new features it just downloaded. See you in a minute!"
-    logger.write("Rebooting")
-    reboot(title, description, is_gui)
+    logger.info("Rebooting")
+    reboot(title, description)

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends: debhelper (>= 9), build-essential, pkg-config, libgtk2.0-dev,
 
 Package: kano-updater
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, kano-toolset, python, zenity
+Depends: ${misc:Depends}, kano-toolset, python, zenity
 Suggests: kano-profile
 Description: Tool to update Kanux
  A tool written in Python to upgrade Debian packages, upgrade Python modules and extend filesystem.

--- a/kano_updater/stages.py
+++ b/kano_updater/stages.py
@@ -11,10 +11,10 @@
 
 import os
 
-import kano.logger as logger
+from kano.logging import logger
 from kano.utils import zenity_show_progress, run_print_output_error, \
     kill_child_processes, run_cmd, read_file_contents_as_lines, delete_file, \
-    delete_dir
+    delete_dir, run_cmd_log
 from kano_updater.utils import fix_broken
 
 def upgrade_debian():
@@ -28,23 +28,17 @@ def upgrade_debian():
     id = zenity_show_progress("Upgrading packages")
     cmd = 'yes "" | apt-get -y -o Dpkg::Options::="--force-confdef" ' + \
           '-o Dpkg::Options::="--force-confold" dist-upgrade'
-    _, debian_err, _ = run_cmd(cmd)
-    for line in debian_err.split("\n"):
-        logger.write(line)
+    _, debian_err, _ = run_cmd_log(cmd)
     kill_child_processes(id)
 
     # apt autoremove
     id = zenity_show_progress("Cleaning up packages")
     cmd = 'apt-get -y autoremove --purge'
-    _, debian_err, _ = run_cmd(cmd)
-    for line in debian_err.split("\n"):
-        logger.write(line)
+    run_cmd_log(cmd)
 
     # apt autoclean
     cmd = 'apt-get -y autoclean'
-    _, debian_err, _ = run_cmd(cmd)
-    for line in debian_err.split("\n"):
-        logger.write(line)
+    run_cmd_log(cmd)
     kill_child_processes(id)
 
     # Try to fix any broken packages after the upgrade
@@ -83,21 +77,21 @@ def upgrade_python(python_modules_file, appstate_before):
         # remove old pip and setuptools
         cmd = 'yes "" | apt-get -y purge python-setuptools ' + \
               'python-virtualenv python-pip'
-        run_print_output_error(cmd)
+        run_cmd_log(cmd)
 
     # installing/upgrading pip
     o, _, _ = run_cmd('pip -V')
     if 'pip 1.' in o:
         cmd = 'pip install --upgrade pip'
-        run_print_output_error(cmd)
+        run_cmd_log(cmd)
     else:
         cmd = 'wget -q --no-check-certificate ' + \
               'https://raw.github.com/pypa/pip/master/contrib/get-pip.py ' + \
               '-O get-pip.py'
-        run_cmd(cmd)
+        run_cmd_log(cmd)
 
         cmd = 'python get-pip.py'
-        run_print_output_error(cmd)
+        run_cmd_log(cmd)
 
         delete_file('get-pip.py')
 
@@ -108,7 +102,7 @@ def upgrade_python(python_modules_file, appstate_before):
     error_modules = []
 
     for module in python_modules:
-        o, e, rc = run_cmd('pip install --upgrade {}'.format(module))
+        o, e, rc = run_cmd_log('pip install --upgrade {}'.format(module))
 
         if rc == 0:
             if 'Successfully installed' in o:

--- a/kano_updater/utils.py
+++ b/kano_updater/utils.py
@@ -9,32 +9,59 @@
 #
 
 import os
+import sys
 import errno
-import kano.logger as logger
+from kano.logging import logger
 from kano.utils import run_print_output_error, run_cmd, run_print_output_error,\
-    zenity_show_progress, kill_child_processes
+    zenity_show_progress, kill_child_processes, run_cmd_log, is_gui
 
 UPDATER_CACHE_DIR = "/var/cache/kano-updater/"
 STATUS_FILE = UPDATER_CACHE_DIR + "status"
 
-
-def install(pkgs):
+def install(pkgs, die_on_err=True):
     if isinstance(pkgs, list):
         pkgs = ' '.join(pkgs)
 
     cmd = 'apt-get install -o Dpkg::Options::="--force-confdef" ' + \
           '-o Dpkg::Options::="--force-confold" -y --force-yes ' + str(pkgs)
-    print cmd
-    run_print_output_error(cmd)
+    _, _, rv = run_cmd_log(cmd)
 
+    if die_on_err and rv != 0:
+        update_failed("Unable to install '{}'".format(pkgs))
+
+    return rv
 
 def remove(pkgs):
     pass  # TODO
 
+def purge(pkgs, die_on_err=False):
+    if isinstance(pkgs, list):
+        pkgs = ' '.join(pkgs)
 
-def purge(pkgs):
-    pass  # TODO
+    _, _, rv = run_cmd_log('apt-get -y purge ' + str(pkgs))
 
+    if die_on_err and rv != 0:
+        update_failed("Unable to purge '{}'".format(pkgs))
+
+    return rv
+
+def update_failed(err):
+    logger.error("Update failed: {}".format(err))
+
+    msg = "The update couldn't be finished at the moment. " + \
+          "Please try again later.\n\n" + \
+          "If this problem persists, please consider reporting this issue " + \
+          "via the\nFeedback tool. We'll be happy to help!"
+
+    if is_gui():
+        from kano.gtk3 import kano_dialog
+        kdialog = kano_dialog.KanoDialog("Update error", msg)
+        kdialog.run()
+    else:
+        print "Update error: {}".format(msg)
+        answer = raw_input()
+
+    sys.exit(1)
 
 def get_dpkg_dict():
     apps_ok = dict()
@@ -56,28 +83,21 @@ def get_dpkg_dict():
 
     return apps_ok, apps_other
 
-
 def fix_broken(msg):
     progress_bar = zenity_show_progress(msg)
     cmd = 'yes "" | apt-get -y -o Dpkg::Options::="--force-confdef" ' + \
           '-o Dpkg::Options::="--force-confold" install -f'
-    _, debian_err, _ = run_cmd(cmd)
+    run_cmd_log(cmd)
     kill_child_processes(progress_bar)
-
-    for line in debian_err.split("\n"):
-        logger.write(line)
-
 
 def expand_rootfs():
     cmd = '/usr/bin/expand-rootfs'
     _, _, rc = run_print_output_error(cmd)
     return rc == 0
 
-
 def get_installed_version(pkg):
     out, _, _ = run_cmd('dpkg-query -s kano-updater | grep "Version:"')
     return out.strip()[9:]
-
 
 def get_update_status():
     status = {"last_update": 0, "update_available": 0, "last_check": 0}
@@ -88,7 +108,6 @@ def get_update_status():
                 status[name] = int(value)
 
     return status
-
 
 def set_update_status(status):
     try:
@@ -103,7 +122,6 @@ def set_update_status(status):
         for name, value in status.iteritems():
             sf.write("{}={}\n".format(name, value))
 
-
 def reboot_required(watched, changed):
     for pkg in changed:
         if pkg in watched:
@@ -111,9 +129,8 @@ def reboot_required(watched, changed):
 
     return False
 
-
-def reboot(title, description, is_gui=False):
-    if is_gui:
+def reboot(title, description):
+    if is_gui():
         from kano.gtk3 import kano_dialog
         kdialog = kano_dialog.KanoDialog(title, description)
         kdialog.run()
@@ -122,7 +139,6 @@ def reboot(title, description, is_gui=False):
         print 'Press any key to continue'
         answer = raw_input()
     run_cmd('reboot')
-
 
 def remove_user_files(files):
     for d in os.listdir("/home/"):


### PR DESCRIPTION
This is a fairly major refactor of the updater's logging and error handling. I haven't tested it throughly yet, we'll need to do that when we're testing updates as usual before the release.

Related to https://github.com/KanoComputing/peldins/issues/859 and https://github.com/KanoComputing/peldins/issues/873

cc @alex5imon 
