### PR TITLE
Run dialogs after the GUI has been killed

### DIFF
--- a/bin/kano-updater
+++ b/bin/kano-updater
@@ -181,9 +181,9 @@ if check_internet():
         kdialog = kano_dialog.KanoDialog('Error!', 'Internet connection lost!')
         kdialog.dialog.set_icon_name("kano-updater")
         kdialog.dialog.set_title("Kano Updater")
+        kill_gui(gui_process)
         kdialog.run()
         logger.error('Internet connection lost before Python upgrades!')
-        kill_gui(gui_process)
         sys.exit()
 
     python_ok, python_err = upgrade_python(appstate_before)
@@ -197,8 +197,8 @@ if check_internet():
         kdialog = kano_dialog.KanoDialog(title, '')
         kdialog.dialog.set_icon_name("kano-updater")
         kdialog.dialog.set_title("Kano Updater")
-        kdialog.run()
         kill_gui(gui_process)
+        kdialog.run()
         sys.exit(title)
 
     # post upgrade


### PR DESCRIPTION
This will make sure the dialogs do not hide under the GUI.

These are all the dialogs I could find.

Feel free to merge @alex5imon if it's ok.

cc @zsero @skarbat
