### PR TITLE
Adding hourglass support to kano-updater menut item

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Section: admin
 Priority: optional
 Standards-Version: 3.9.2
 Build-Depends: debhelper (>= 9), build-essential, pkg-config, libgtk2.0-dev,
-               libmenu-cache1-dev, lxpanel, libfm-gtk1, libfm-dev
+               libmenu-cache1-dev, lxpanel, libfm-gtk1, libfm-dev, libkdesk-dev
 
 Package: kano-updater
 Architecture: any
@@ -12,6 +12,3 @@ Depends: ${misc:Depends}, kano-toolset (>= 1.1-4), python, gir1.2-gtk-3.0
 Suggests: kano-profile
 Description: Tool to update Kanux
  A tool written in Python to upgrade Debian packages, upgrade Python modules and extend filesystem.
-
-
-

--- a/lxpanel-plugin/Makefile
+++ b/lxpanel-plugin/Makefile
@@ -3,7 +3,7 @@
 
 CC=gcc
 CFLAGS=`pkg-config --cflags lxpanel gtk+-2.0` -I/usr/include/libfm
-LIBS=`pkg-config --libs lxpanel gtk+-2.0` -lfm-gtk
+LIBS=`pkg-config --libs lxpanel gtk+-2.0` -lfm-gtk -lkdesk-hourglass
 SRC=kano_updater.c
 BIN=kano_updater.so
 INSTALL_PATH=/usr/lib/arm-linux-gnueabihf/lxpanel/plugins/

--- a/lxpanel-plugin/kano_updater.c
+++ b/lxpanel-plugin/kano_updater.c
@@ -19,6 +19,8 @@
 #include <ctype.h>
 #include <time.h>
 
+#include <kdesk-hourglass.h>
+
 #define DEFAULT_ICON_FILE "/usr/share/kano-updater/images/panel-default.png"
 #define NOTIFICATION_ICON_FILE "/usr/share/kano-updater/images/panel-notification.png"
 #define UPDATE_STATUS_FILE "/var/cache/kano-updater/status"
@@ -201,6 +203,7 @@ static gboolean update_status(kano_updater_plugin_t *plugin)
 
 void update_clicked(GtkWidget *widget, gpointer data)
 {
+        kdesk_hourglass_start("kano-updater");
 	launch_cmd(UPDATE_CMD);
 }
 


### PR DESCRIPTION
- When clicking on the update system menu item
  an hourglass mouse pointer as requested to kdesk
