### PR TITLE
Fix image in the check for updates window

### DIFF
--- a/bin/check-for-updates
+++ b/bin/check-for-updates
@@ -32,7 +32,7 @@ from kano.gtk3.buttons import KanoButton, OrangeButton
 from kano.gtk3.heading import Heading
 from kano.gtk3.apply_styles import apply_common_to_screen
 
-update_image = "/usr/share/kano-updater/images/update-screen.png"
+update_image = "/usr/lib/python2.7/dist-packages/kano_updater_gui/media/images/update-screen.png"
 
 
 class MainWindow(Gtk.Window):


### PR DESCRIPTION
The image used for the check for updates screen was moved but the path
wasn't updated, so update it.