### PR TITLE
I18n gettext hooks for kano-updater-gui, kano-updater and check-for-updates (3rd try)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.pyc
 *.pyo
 *~
+*.mo
+po/messages.pot

--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -40,6 +40,24 @@ If you added new message strings or made changes to existing ones, do `make mess
 
 After that, merge the existing translations with `make update` and ask your translators to update their translations.
 
+## gettext explained (in 20 seconds)
+
+* User-visible strings in the source are marked with a macro of your choice. Usually, it's `_()`.
+* `xgettext` extracts these message strings from your sources and puts them into a template file.
+* This template file, usually named `messages.pot`, contains all user-visible strings of the project, but no translations.
+* Translators use `msginit` to copy the template file into a new *portable object* file for their language (explained above).
+* The translations are put into `<lang>.po`. It's a plain-text file format, you can use any text editor.
+* More convenient, specialized `.po`-editors and web-based tools such as Pootle exist, as well.
+* If your template file changes, use `msgmerge` to merge your existing translations with the new template, then re-translate the updated messages. Beware of `msgmerge`'s "fuzzy" matches.
+* `msgfmt` converts a `.po` file into a binary *message object* file.
+* You don't link these `.mo` files with your application binary.
+* The `.mo` files are bundled alongside with your software as part of the distribution package.
+* During installation, the `.mo` files are copied into the system's locale directory, usually `/usr/share/locale`.
+* On startup, your application will look for the message object file that it needs for the current system locale.
+* The locale even allows you to provide region-specific translations, e.g. "colour" for en_UK vs "color" for en_US.
+* At runtime, all user-visible strings are being replaced with the translations.
+* If no message object was found for the system locale, the original strings will be shown. 
+
 ## To-Do
 
 Pootle or Transifex integration.

--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -1,0 +1,45 @@
+# Translation
+
+Translation files are found in the `po/` directory.
+
+## i18n not released yet
+
+Kano OS is not fully i18n-aware and locales are not installed for end users, yet. You can translate this application, but as of now, users will still see the default English message strings.
+
+## How to add a new translation
+
+In this example, we're going to add a French translation:
+
+    # install your target locale `fr_FR.utf8` with:
+    sudo dpkg-reconfigure locales
+    
+    cd po/
+    # create messages.pot
+    make messages
+    
+    # create fr.po from messages.pot:
+    msginit -l fr_FR.utf8
+    
+    # now use your favourite editor to translate fr.po
+    
+    # build locale files:
+    make
+    
+    # test kano-updater-gui with translated message strings:
+    cd ..
+    LC_ALL=fr_FR.utf8 ./bin/kano-updater-gui
+    
+    # test with 1 through 6 for the 6 stages of kano-updater-gui
+    echo -n 1 > /tmp/updater-progress
+
+## How to make sure your code is i18n-aware
+
+Add the gettext `_()` macro to all the user-visible message strings in your Python or C code. List the Python source files that contain message strings in `PYPOTFILES` and the C source files in `CPOTFILES`.
+
+If you added new message strings or made changes to existing ones, do `make messages` to keep the template file up-to-date.
+
+After that, merge the existing translations with `make update` and ask your translators to update their translations.
+
+## To-Do
+
+Pootle or Transifex integration.

--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -29,7 +29,7 @@ In this example, we're going to add a French translation:
     cd ..
     LC_ALL=fr_FR.utf8 ./bin/kano-updater-gui
     
-    # test with 1 through 6 for the 6 stages of kano-updater-gui
+    # test with 1 through 7 for the 7 stages of kano-updater-gui
     echo -n 1 > /tmp/updater-progress
 
 ## How to make sure your code is i18n-aware

--- a/bin/check-for-updates
+++ b/bin/check-for-updates
@@ -17,11 +17,17 @@ import re
 import time
 import argparse
 import subprocess
+import gettext
 
 if __name__ == '__main__' and __package__ is None:
     dir_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
     if dir_path != '/usr':
-            sys.path.append(dir_path)
+        sys.path.append(dir_path)
+        locale_path = os.path.join(dir_path, 'locale')
+    else:
+        locale_path = None
+
+gettext.install('kano-updater', locale_path, unicode=1)
 
 from kano.utils import run_cmd, enforce_root, is_running
 from kano.logging import logger
@@ -37,7 +43,7 @@ update_image = "/usr/lib/python2.7/dist-packages/kano_updater_gui/media/images/u
 
 class MainWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title='New Update')
+        Gtk.Window.__init__(self, title=_('New Update'))
 
         apply_common_to_screen()
 
@@ -55,14 +61,13 @@ class MainWindow(Gtk.Window):
         self.set_keep_above(True)
 
         # Header
-        self.heading = Heading("Time to update!", "Take a break!  Updating takes about 15 minutes")
+        self.heading = Heading(_("Time to update!"), _("Take a break! Updating takes about 15 minutes"))
         self.heading.description.set_line_wrap(True)
 
-        self.button = KanoButton("UPDATE NOW")
-        self.button.connect("button_release_event", self.update)
-        self.button.connect("key_release_event", self.update)
-        self.later = OrangeButton("Later")
-        self.later.connect("button_release_event", Gtk.main_quit)
+        self.button = KanoButton(_("Update now").upper())
+        self.button.connect("clicked", self.update)
+        self.later = OrangeButton(_("Later"))
+        self.later.connect("clicked", Gtk.main_quit)
         self.button_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=15)
         self.button_box.pack_start(self.button, False, False, 0)
         self.button_box.pack_start(self.later, False, False, 0)

--- a/bin/kano-updater
+++ b/bin/kano-updater
@@ -15,6 +15,7 @@
 import os
 import sys
 import time
+import gettext
 
 from gi.repository import Gtk
 
@@ -22,6 +23,11 @@ if __name__ == '__main__' and __package__ is None:
     dir_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
     if dir_path != '/usr':
         sys.path.insert(0, dir_path)
+        locale_path = os.path.join(dir_path, 'locale')
+    else:
+        locale_path = None
+
+gettext.install('kano-updater', locale_path, unicode=1)
 
 from kano.logging import logger, cleanup
 from kano_updater.osversion import OSVersion, bump_system_version
@@ -61,7 +67,7 @@ showDialogue = not (len(sys.argv) == 2 and
 debug = (len(sys.argv) == 2 and sys.argv[1] in ['-d', '--debug'])
 
 if not is_gui():
-    sys.exit('You need to run kano-updater from a GUI session!')
+    sys.exit(_('You need to run kano-updater from a GUI session!'))
 
 
 # Track application usage only after we are ok to proceed
@@ -84,13 +90,13 @@ cleanup()
 preup = PreUpdate(old_version, new_version)
 postup = PostUpdate(old_version, new_version)
 if not (preup.covers_update() and postup.covers_update()):
-    title = 'Unfortunately, your version of Kano OS is too old ' + \
-            'to be updated through the updater.'
-    description = 'You will need to download the image of the ' + \
-                  'OS and reflash your SD card.'
+    title = _('Unfortunately, your version of Kano OS is too old '
+            'to be updated through the updater.')
+    description = _('You will need to download the image of the '
+                  'OS and reflash your SD card.')
     kdialog = kano_dialog.KanoDialog(title, description)
     kdialog.dialog.set_icon_name("kano-updater")
-    kdialog.dialog.set_title("Kano Updater")
+    kdialog.dialog.set_title(_("Kano Updater"))
     kdialog.run()
     sys.exit(title)
 
@@ -99,16 +105,14 @@ logger.info("Upgrading to: {}".format(str(new_version)))
 
 # ask confirmation from user
 if not forceUpdate and showDialogue:
-    title = "Let\'s update!"
-    description = "Your Kano is about to get better"
     kdialog = kano_dialog.KanoDialog(
-        title,
-        description,
-        button_dict={"UPDATE NOW": {"return_value": 0}},
-        orange_info={"name": "Later", "return_value": 1}
+        _("Let\'s update!"),
+        _("Your Kano is about to get better"),
+        button_dict={_("Update now").upper(): {"return_value": 0}},
+        orange_info={"name": _("Later"), "return_value": 1}
     )
     kdialog.dialog.set_icon_name("kano-updater")
-    kdialog.dialog.set_title("Kano Updater")
+    kdialog.dialog.set_title(_("Kano Updater"))
     response = kdialog.run()
     if response != 0:
         logger.info("Canceled by the user.")
@@ -188,9 +192,9 @@ if check_internet():
 
     # if internet connection is lost during update, do not continue
     if not is_internet():
-        kdialog = kano_dialog.KanoDialog('Error!', 'Internet connection lost!')
+        kdialog = kano_dialog.KanoDialog(_('Error!'), _('Internet connection lost!'))
         kdialog.dialog.set_icon_name("kano-updater")
-        kdialog.dialog.set_title("Kano Updater")
+        kdialog.dialog.set_title(_("Kano Updater"))
         kill_gui(gui_process)
         kdialog.run()
         logger.error('Internet connection lost before Python upgrades!')
@@ -203,10 +207,9 @@ if check_internet():
 
     # check for download error
     if debian_err_packages == -1:
-        title = 'Error with downloading packages!'
-        kdialog = kano_dialog.KanoDialog(title, '')
+        kdialog = kano_dialog.KanoDialog(_('Error with downloading packages!'), '')
         kdialog.dialog.set_icon_name("kano-updater")
-        kdialog.dialog.set_title("Kano Updater")
+        kdialog.dialog.set_title(_("Kano Updater"))
         kill_gui(gui_process)
         kdialog.run()
         sys.exit(title)

--- a/bin/kano-updater-gui
+++ b/bin/kano-updater-gui
@@ -14,12 +14,18 @@ import threading
 import os
 import time
 import sys
+import gettext
 from kano.gtk3.apply_styles import apply_styling_to_screen
 
 if __name__ == '__main__' and __package__ is None:
     dir_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
     if dir_path != '/usr':
         sys.path.insert(1, dir_path)
+        locale_path = os.path.join(dir_path, 'locale')
+    else:
+        locale_path = None
+
+gettext.install('kano-updater', locale_path, unicode=1)
 
 from kano_updater_gui.paths import IMAGE_PATH, CSS_PATH
 from kano_updater_gui.text import NUMBER_OF_STAGES
@@ -88,7 +94,7 @@ class MainWindow(Gtk.Window):
         self.set_keep_above(True)
 
         self.set_icon_name("kano-updater")
-        self.set_title("Updater")
+        self.set_title(_("Updater"))
 
         grid = Gtk.Grid()
 

--- a/bin/kano-updater-gui
+++ b/bin/kano-updater-gui
@@ -156,7 +156,7 @@ class MainWindow(Gtk.Window):
         self.set_stages(current_number)
         self.start_spinner()
 
-    # number is the current working state (1-6) minus one (0-5)!
+    # number is the current working state (1-7) minus one (0-6)!
     def set_stages(self, number):
         self.headerstack.set_visible_child(self.headers[number])
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-updater (1.3-2) unstable; urgency=low
+
+  * Adding gettext integration.
+
+ -- Team Kano <dev@kano.me>  Wed, 25 Feb 2014 12:16:00 +0000
+
 kano-updater (1.3-1) unstable; urgency=low
 
   * Bumping updater to 1.3

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends: debhelper (>= 9), build-essential, pkg-config, libgtk2.0-dev,
 
 Package: kano-updater
 Architecture: any
-Depends: ${misc:Depends}, kano-toolset (>= 1.2-5), python, libkdesk-dev,
+Depends: ${misc:Depends}, kano-toolset (>= 1.3-10), python, libkdesk-dev,
  gir1.2-gtk-3.0 (>= 3.10.2), kano-settings (>= 1.3-1)
 Suggests: kano-profile
 Description: Tool to update Kanux

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Section: admin
 Priority: optional
 Standards-Version: 3.9.2
 Build-Depends: debhelper (>= 9), build-essential, pkg-config, libgtk2.0-dev,
-               lxpanel (>= 0.7.0), libfm-dev, libkdesk-dev
+               lxpanel (>= 0.7.0), libfm-dev, libkdesk-dev, gettext
 
 Package: kano-updater
 Architecture: any

--- a/debian/install
+++ b/debian/install
@@ -10,3 +10,5 @@ lxpanel-plugin/*.png usr/share/kano-updater/images/
 
 icon/updater.app usr/share/applications/
 icon/kano-updater.png usr/share/icons/Kano/66x66/apps/
+
+locale/* /usr/share/locale

--- a/debian/rules
+++ b/debian/rules
@@ -5,4 +5,5 @@
 
 override_dh_auto_build:
 	cd lxpanel-plugin && make
+	cd po && make
 	dh_auto_build

--- a/kano_updater/utils.py
+++ b/kano_updater/utils.py
@@ -62,11 +62,11 @@ def update_failed(err):
 
     logger.error("Update failed: {}".format(err))
 
-    msg = "We had a problem with the Update. " + \
-          "Make sure you are connected to the Internet, and give it another go.\n\n" + \
-          "If you still have problems, we can help at http://help.kano.me"
+    msg = _("We had a problem with the Update. "
+          "Make sure you are connected to the Internet, and give it another go.\n\n"
+          "If you still have problems, we can help at http://help.kano.me")
 
-    kdialog = kano_dialog.KanoDialog("Update error", msg)
+    kdialog = kano_dialog.KanoDialog(_("Update error"), msg)
     kdialog.run()
 
 
@@ -320,12 +320,14 @@ def root_check():
 
     user = os.environ['LOGNAME']
     if user != 'root':
-        title = 'Error!'
         description = 'kano-updater must be executed with root privileges'
         logger.error(description)
 
         if is_gui():
-            kdialog = kano_dialog.KanoDialog(title, description)
+            kdialog = kano_dialog.KanoDialog(
+                _('Error!'),
+                _('kano-updater must be executed with root privileges')
+            )
             kdialog.run()
         sys.exit(description)
 

--- a/kano_updater_gui/header.py
+++ b/kano_updater_gui/header.py
@@ -107,14 +107,14 @@ class Header(Gtk.EventBox):
             margin_bottom = 25
         )
 
-        if number < 5:
+        if number < NUMBER_OF_STAGES:
             psa_bang = Gtk.Image()
             psa_bang.set_from_file("{}/bang.png".format(IMAGE_PATH))
             psa_grid.add(psa_bang)
 
         psa_label = Gtk.Label(
             (_(u"Do not disconnect your Kano")
-            if number < 5 else
+            if number < NUMBER_OF_STAGES else
             _(u"Please stand by")).upper()
         )
         psa_label.get_style_context().add_class("psa")

--- a/kano_updater_gui/header.py
+++ b/kano_updater_gui/header.py
@@ -113,9 +113,9 @@ class Header(Gtk.EventBox):
             psa_grid.add(psa_bang)
 
         psa_label = Gtk.Label(
-            (u"Do not disconnect your Kano"
+            (_(u"Do not disconnect your Kano")
             if number < 5 else
-            u"Please stand by").upper()
+            _(u"Please stand by")).upper()
         )
         psa_label.get_style_context().add_class("psa")
         psa_grid.add(psa_label)

--- a/kano_updater_gui/text.py
+++ b/kano_updater_gui/text.py
@@ -9,28 +9,28 @@
 #
 
 STATUS_TITLES = [
-    u"1. Downloading\N{HORIZONTAL ELLIPSIS}",
-    u"2. Updating\nthe updater\N{HORIZONTAL ELLIPSIS}",
-    u"3. Upgrading\nPython\N{HORIZONTAL ELLIPSIS}",
-    u"4. Optimizing\nyour Kano\N{HORIZONTAL ELLIPSIS}",
-    u"5. Upgrading\nyour system\N{HORIZONTAL ELLIPSIS}",
-    u"6. Finishing\nup\N{HORIZONTAL ELLIPSIS}"
+    _(u"1. Downloading\N{HORIZONTAL ELLIPSIS}"),
+    _(u"2. Updating\nthe updater\N{HORIZONTAL ELLIPSIS}"),
+    _(u"3. Upgrading\nPython\N{HORIZONTAL ELLIPSIS}"),
+    _(u"4. Optimizing\nyour Kano\N{HORIZONTAL ELLIPSIS}"),
+    _(u"5. Upgrading\nyour system\N{HORIZONTAL ELLIPSIS}"),
+    _(u"6. Finishing\nup\N{HORIZONTAL ELLIPSIS}")
 ]
 
 NUMBER_OF_STAGES = len(STATUS_TITLES)
 
 STAGE_TITLES = [
-    u"Downloading\N{HORIZONTAL ELLIPSIS}",
-    u"Updating the updater\N{HORIZONTAL ELLIPSIS}",
-    u"Upgrading Python\N{HORIZONTAL ELLIPSIS}",
-    u"Optimizing your Kano\N{HORIZONTAL ELLIPSIS}",
-    u"Upgrading your Operating System\N{HORIZONTAL ELLIPSIS}",
-    u"Finishing up\N{HORIZONTAL ELLIPSIS}",
-    u"System updated!"
+    _(u"Downloading\N{HORIZONTAL ELLIPSIS}"),
+    _(u"Updating the updater\N{HORIZONTAL ELLIPSIS}"),
+    _(u"Upgrading Python\N{HORIZONTAL ELLIPSIS}"),
+    _(u"Optimizing your Kano\N{HORIZONTAL ELLIPSIS}"),
+    _(u"Upgrading your Operating System\N{HORIZONTAL ELLIPSIS}"),
+    _(u"Finishing up\N{HORIZONTAL ELLIPSIS}"),
+    _(u"System updated!")
 ]
 
 STAGE_BODIES = [
-    u"In 1978, the fastest computer in the world was the "
+    _(u"In 1978, the fastest computer in the world was the "
     u"Cray 1 \N{EM DASH} it cost $7 million and weighed as "
     u"much as an average elephant! Your Kano is about 4 "
     u"times faster than the Cray 1. To keep it up to speed, "
@@ -40,9 +40,9 @@ STAGE_BODIES = [
     u"phone picture of your Kano? Send it to us at "
     u"<b>hello@kano.me</b> and we'll share it with the "
     u"world. You can also search for the white rabbit on "
-    u"<b>http://world.kano.me</b>",
+    u"<b>http://world.kano.me</b>"),
 
-    u"Computers can learn new ideas quickly. Right now, "
+    _(u"Computers can learn new ideas quickly. Right now, "
     u"we're updating the Updater tool. Once this step is "
     u"finished, the Updater will relaunch. How do computers "
     u"think? They are made of electrical switches, "
@@ -53,9 +53,9 @@ STAGE_BODIES = [
     u"and more. Your computer has over 10 million tiny "
     u"switches, called transistors, in its brain. In your "
     u"brain, these switches are cells called neurons. "
-    u"They're talking to each other right now.",
+    u"They're talking to each other right now."),
 
-    u"Python is one of the world's most popular programming "
+    _(u"Python is one of the world's most popular programming "
     u"languages. A programming language takes words that "
     u"humans can understand, and translates them into "
     u"instructions that the computer's switches can "
@@ -67,21 +67,21 @@ STAGE_BODIES = [
     u"recipe in English. Python code can build volcanos in "
     u"Minecraft, grab \"Gangnam Style\" from YouTube, and "
     u"move millions of dollars in the New York Stock "
-    u"Exchange.",
+    u"Exchange."),
 
-    u"The name \"Kano\" comes from Kan\u014d Jigor\u014d. He "
+    _(u"The name \"Kano\" comes from Kan\u014d Jigor\u014d. He "
     u"was a Japanese schoolteacher, inventor of the art of judo. "
     u"His motto: Maximum efficiency, minimum effort. In "
     u"Greek, Kano means \"I make\". (Kano is also the largest "
     u"city in Northern Nigeria.) What makes Kano different to "
     u"other computers? All of the ideas in its brain are open "
     u"for you to see. Just visit <b>github.com/KanoComputing</b> "
-    u"to see the code. Kano can also change forms... You can "
-    u"turn it into a robot, server, radio, and more. Visit "
+    u"to see the code. Kano can also change forms\N{HORIZONTAL ELLIPSIS} "
+    u"You can turn it into a robot, server, radio, and more. Visit "
     u"<b>world.kano.me/projects</b> for powerup ideas. Want a look "
-    u"inside Kano HQ? Hang with our wizards at <b>blog.kano.me</b>",
+    u"inside Kano HQ? Hang with our wizards at <b>blog.kano.me</b>"),
 
-    u"Kano OS is an operating system, which means it "
+    _(u"Kano OS is an operating system, which means it "
     u"connects all the programs together. This OS is based "
     u"on Linux, whose code is open \N{EM DASH} that means "
     u"that it's free for anyone to download, change or even "
@@ -90,16 +90,16 @@ STAGE_BODIES = [
     u"a fun and powerful \"distribution\" of Linux which "
     u"the International Space Station also uses to run its "
     u"robotic systems \N{EM DASH} to keep the astronauts "
-    u"from losing their lunch!",
+    u"from losing their lunch!"),
 
-    u"We're almost done! With your Kano computer, you'll "
+    _(u"We're almost done! With your Kano computer, you'll "
     u"make awesome games, code your own music, stream "
     u"videos around your house, tell stories, and much "
     u"more. Your computer is open, and its powers are at "
     u"your command. If you want to get new cool projects "
-    u"from us each week, join the community at",
+    u"from us each week, join the community at"),
 
-    u"Your Kano will now reboot!\n"
+    _(u"Your Kano will now reboot!\n"
     u"\n"
-    u"See you in a while\N{HORIZONTAL ELLIPSIS}"
+    u"See you in a while\N{HORIZONTAL ELLIPSIS}")
 ]

--- a/lxpanel-plugin/kano_updater.c
+++ b/lxpanel-plugin/kano_updater.c
@@ -8,7 +8,8 @@
 
 #include <gtk/gtk.h>
 #include <gdk/gdk.h>
-#include <glib/gi18n.h>
+#define GETTEXT_PACKAGE "kano-updater"
+#include <glib/gi18n-lib.h>
 #include <gdk-pixbuf/gdk-pixbuf.h>
 #include <gio/gio.h>
 
@@ -29,7 +30,7 @@
 #define UPDATE_CMD "kdesk-blur 'sudo /usr/bin/kano-updater'"
 #define SOUND_CMD "/usr/bin/aplay /usr/share/kano-media/sounds/kano_open_app.wav"
 
-#define PLUGIN_TOOLTIP "Kano Updater"
+#define PLUGIN_TOOLTIP _("Kano Updater")
 
 #define DAY 60*60*24
 
@@ -239,24 +240,24 @@ static gboolean show_menu(GtkWidget *widget, GdkEventButton *event,
 	update_status(plugin);
 
 	/* Create the menu items */
-	header_item = gtk_menu_item_new_with_label("Kano Updater");
+	header_item = gtk_menu_item_new_with_label(_("Kano Updater"));
 	gtk_widget_set_sensitive(header_item, FALSE);
 	gtk_menu_append(GTK_MENU(menu), header_item);
 	gtk_widget_show(header_item);
 
 	if (plugin->update_available > 0) {
-		update_item = gtk_menu_item_new_with_label("Update your system");
+		update_item = gtk_menu_item_new_with_label(_("Update your system"));
 		g_signal_connect(update_item, "activate",
 				 G_CALLBACK(update_clicked), NULL);
 		gtk_menu_append(GTK_MENU(menu), update_item);
 		gtk_widget_show(update_item);
 	} else {
-		no_updates_item = gtk_menu_item_new_with_label("No updates found");
+		no_updates_item = gtk_menu_item_new_with_label(_("No updates found"));
 		gtk_widget_set_sensitive(no_updates_item, FALSE);
 		gtk_menu_append(GTK_MENU(menu), no_updates_item);
 		gtk_widget_show(no_updates_item);
 
-		check_item = gtk_menu_item_new_with_label("Check again");
+		check_item = gtk_menu_item_new_with_label(_("Check again"));
 		g_signal_connect(check_item, "activate",
 				 G_CALLBACK(check_for_update_clicked),
 				 plugin);

--- a/po/CPOTFILES
+++ b/po/CPOTFILES
@@ -1,0 +1,1 @@
+../lxpanel-plugin/kano_updater.c

--- a/po/Makefile
+++ b/po/Makefile
@@ -1,0 +1,33 @@
+APPNAME=kano-updater
+
+MSGLANGS=$(notdir $(wildcard *po))
+MSGOBJS=$(addprefix ../locale/,$(MSGLANGS:.po=/LC_MESSAGES/$(APPNAME).mo))
+
+.PHONY: clean messages
+
+build: $(MSGOBJS)
+
+update: $(MSGLANGS)
+
+clean:
+	rm -f messages.pot
+	rm -rf ../locale
+
+define run-xgettext
+xgettext -f PYPOTFILES -L Python --force-po -o messages.pot
+xgettext -f CPOTFILES -L C -k_ -kN_ -j -o messages.pot
+endef
+
+messages:
+	$(run-xgettext)
+
+messages.pot:
+	$(run-xgettext)
+
+%.po: messages.pot
+	msgmerge -N -U $*.po messages.pot
+	touch $*.po
+
+../locale/%/LC_MESSAGES/$(APPNAME).mo: %.po
+	mkdir -p $(dir $@)
+	msgfmt -c -o $@ $*.po

--- a/po/Makefile
+++ b/po/Makefile
@@ -1,4 +1,5 @@
 APPNAME=kano-updater
+ORG="Kano Computing Ltd."
 
 MSGLANGS=$(notdir $(wildcard *po))
 MSGOBJS=$(addprefix ../locale/,$(MSGLANGS:.po=/LC_MESSAGES/$(APPNAME).mo))
@@ -16,8 +17,10 @@ clean: clean_locales
 	rm -f messages.pot
 
 define run-xgettext
-xgettext -f PYPOTFILES -L Python --force-po -o messages.pot
-xgettext -f CPOTFILES -L C -k_ -kN_ -j -o messages.pot
+xgettext -f PYPOTFILES -L Python --force-po -o messages.pot \
+    --package-name=$(APPNAME) --copyright-holder=$(ORG)
+xgettext -f CPOTFILES -L C -k_ -kN_ -j -o messages.pot \
+    --package-name=$(APPNAME) --copyright-holder=$(ORG)
 endef
 
 messages:

--- a/po/Makefile
+++ b/po/Makefile
@@ -3,15 +3,17 @@ APPNAME=kano-updater
 MSGLANGS=$(notdir $(wildcard *po))
 MSGOBJS=$(addprefix ../locale/,$(MSGLANGS:.po=/LC_MESSAGES/$(APPNAME).mo))
 
-.PHONY: clean messages
+.PHONY: clean_locales messages
 
 build: $(MSGOBJS)
 
 update: $(MSGLANGS)
 
-clean:
-	rm -f messages.pot
+clean_locales:
 	rm -rf ../locale
+
+clean: clean_locales
+	rm -f messages.pot
 
 define run-xgettext
 xgettext -f PYPOTFILES -L Python --force-po -o messages.pot
@@ -28,6 +30,6 @@ messages.pot:
 	msgmerge -N -U $*.po messages.pot
 	touch $*.po
 
-../locale/%/LC_MESSAGES/$(APPNAME).mo: %.po
+../locale/%/LC_MESSAGES/$(APPNAME).mo: clean_locales
 	mkdir -p $(dir $@)
 	msgfmt -c -o $@ $*.po

--- a/po/PYPOTFILES
+++ b/po/PYPOTFILES
@@ -1,0 +1,4 @@
+../bin/kano-updater-gui
+../kano_updater_gui/text.py
+../kano_updater_gui/header.py
+../kano_updater_gui/stage.py

--- a/po/PYPOTFILES
+++ b/po/PYPOTFILES
@@ -1,4 +1,7 @@
+../bin/check-for-updates
+../bin/kano-updater
 ../bin/kano-updater-gui
+../kano_updater/utils.py
 ../kano_updater_gui/text.py
 ../kano_updater_gui/header.py
 ../kano_updater_gui/stage.py

--- a/po/de.po
+++ b/po/de.po
@@ -1,12 +1,12 @@
-# German translations for PACKAGE package
-# German messages for PACKAGE.
-# Copyright (C) 2015 THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
+# German translations for kano-updater package
+# German messages for kano-updater.
+# Copyright (C) 2015 Kano Computing Ltd.
+# This file is distributed under the same license as the kano-updater package.
 #  <kontakt@hanno.de>, 2015.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: kano-updater\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2015-02-23 14:02+0100\n"
 "PO-Revision-Date: 2015-02-13 17:16+0100\n"

--- a/po/de.po
+++ b/po/de.po
@@ -1,0 +1,250 @@
+# German translations for PACKAGE package
+# German messages for PACKAGE.
+# Copyright (C) 2015 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#  <kontakt@hanno.de>, 2015.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-02-19 14:28+0100\n"
+"PO-Revision-Date: 2015-02-13 17:16+0100\n"
+"Last-Translator:  <kontakt@hanno.de>\n"
+"Language-Team: German <kontakt@hanno.de>\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../bin/kano-updater-gui:97
+msgid "Updater"
+msgstr "Updater"
+
+#: ../kano_updater_gui/text.py:12
+msgid "1. Downloading…"
+msgstr "1. Vorbereitung…"
+
+#: ../kano_updater_gui/text.py:13
+msgid ""
+"2. Updating\n"
+"the updater…"
+msgstr ""
+"2. Updates für\n"
+"den Updater…"
+
+#: ../kano_updater_gui/text.py:14
+msgid ""
+"3. Upgrading\n"
+"Python…"
+msgstr ""
+"3. Updates für\n"
+"Python…"
+
+#: ../kano_updater_gui/text.py:15
+msgid ""
+"4. Optimizing\n"
+"your Kano…"
+msgstr ""
+"4. Verbesserungen\n"
+"für Deinen Kano…"
+
+#: ../kano_updater_gui/text.py:16
+msgid ""
+"5. Upgrading\n"
+"your system…"
+msgstr ""
+"5. Updates für\n"
+"Dein System…"
+
+#: ../kano_updater_gui/text.py:17
+msgid ""
+"6. Finishing\n"
+"up…"
+msgstr "6. Aufräumen…"
+
+#: ../kano_updater_gui/text.py:23
+msgid "Downloading…"
+msgstr "Vorbereitung…"
+
+#: ../kano_updater_gui/text.py:24
+msgid "Updating the updater…"
+msgstr "Updates für den Updater…"
+
+#: ../kano_updater_gui/text.py:25
+msgid "Upgrading Python…"
+msgstr "Updates für Python…"
+
+#: ../kano_updater_gui/text.py:26
+msgid "Optimizing your Kano…"
+msgstr "Verbesserungen für Deinen Kano…"
+
+#: ../kano_updater_gui/text.py:27
+msgid "Upgrading your Operating System…"
+msgstr "Updates für Dein Betriebssystem…"
+
+#: ../kano_updater_gui/text.py:28
+msgid "Finishing up…"
+msgstr "Aufräumen…"
+
+#: ../kano_updater_gui/text.py:29
+msgid "System updated!"
+msgstr "System auf neuestem Stand!"
+
+#: ../kano_updater_gui/text.py:33
+msgid ""
+"In 1978, the fastest computer in the world was the Cray 1 — it cost $7 "
+"million and weighed as much as an average elephant! Your Kano is about 4 "
+"times faster than the Cray 1. To keep it up to speed, we're downloading new "
+"games, apps and projects, and streamlining the computer's memory. This "
+"should take about 15 minutes. In the meantime, why not take a phone picture "
+"of your Kano? Send it to us at <b>hello@kano.me</b> and we'll share it with "
+"the world. You can also search for the white rabbit on <b>http://world.kano."
+"me</b>"
+msgstr ""
+"1978 war die Cray 1 der schnellste Computer der Welt — sie kostete 7 "
+"Millionen US-Dollar und war so schwer wie ein Elefant! Dein Kano ist ca. "
+"vier mal so schnell wie die Cray 1. Damit er auf Zack bleibt, optimieren wir "
+"jetzt seinen Speicher und laden neue Spiele, Apps und Projekte herunter. Das "
+"wird eine gute Viertelstunde dauern. Wie wär's, wenn Du währenddessen ein "
+"Foto von Deinem Kano machst? Schick's an <b>hello@kano.me</b> und wir teilen "
+"es mit der Welt. Oder komm zu <b>http://world.kano.me</b> und suche das "
+"weiße Kaninchen."
+
+#: ../kano_updater_gui/text.py:45
+msgid ""
+"Computers can learn new ideas quickly. Right now, we're updating the Updater "
+"tool. Once this step is finished, the Updater will relaunch. How do "
+"computers think? They are made of electrical switches, connected together in "
+"clever ways. If a switch is on, that means \"yes\" or \"1\"; if it's off, "
+"that means \"no\" or \"0\". These little yes-no switches become a binary "
+"code — for words, sounds, rules, and more. Your computer has over 10 million "
+"tiny switches, called transistors, in its brain. In your brain, these "
+"switches are cells called neurons. They're talking to each other right now."
+msgstr ""
+"Computer können schnell neue Ideen lernen. Im Moment aktualisieren wir den "
+"Updater. Wenn das erledigt ist wird der Updater neu starten. Wie denken "
+"Computer? Sie bestehen aus winzigen elektrischen Schaltern, die in tollen "
+"Schaltkreisen miteinander verdrahtet sind. Ist der Schalter an, heißt das "
+"\"Ja\" oder \"1\", ist er aus, heißt das \"Nein\" oder \"0\". Diese kleinen "
+"Ja-Nein-Schalter bilden einen binären Code — und daraus werden Wörter, Töne, "
+"Regeln und mehr. Die Schalter im Gehirn Deines Computer heißen Transistoren, "
+"und es sind über 10 Million drin. Die Schalter in Deinem Gehirn sind Zellen "
+"und heißen Neuronen. Jetzt gerade reden sie miteinander."
+
+#: ../kano_updater_gui/text.py:58
+msgid ""
+"Python is one of the world's most popular programming languages. A "
+"programming language takes words that humans can understand, and translates "
+"them into instructions that the computer's switches can understand. A good "
+"\"make a sandwich\" program would go through all the steps necessary to get "
+"the sandwich made, from \"grab bread\" to \"pick up knife\" to \"put it on a "
+"plate.\" The computer follows a program in Python the way a cook follows a "
+"recipe in English. Python code can build volcanos in Minecraft, grab "
+"\"Gangnam Style\" from YouTube, and move millions of dollars in the New York "
+"Stock Exchange."
+msgstr ""
+"Python ist eine der beliebtesten Programmiersprachen der Welt. Eine "
+"Programmiersprache übersetzt Wörter, die ein Mensch verstehen kann, in "
+"Anweisungen, welche die Schalter des Computers verstehen. Ein gut "
+"durchdachtes \"Mach mir ein Sandwich\"-Programm würde alle Schritte für die "
+"Sandwich-Zubereitung beschreiben, von \"hole eine Scheibe Brot\" über \"nimm "
+"das Messer\" bis \"leg's auf den Teller\". Ein Computer befolgt ein Python-"
+"Programm so, wie ein Koch ein Rezept befolgt. Python-Code kann Vulkane in "
+"Minecraft bauen, \"Gangnam Style\" von Youtube ziehen und Millionen US-"
+"Dollar an der New Yorker Börse bewegen."
+
+#: ../kano_updater_gui/text.py:72
+msgid ""
+"The name \"Kano\" comes from Kanō Jigorō. He was a Japanese schoolteacher, "
+"inventor of the art of judo. His motto: Maximum efficiency, minimum effort. "
+"In Greek, Kano means \"I make\". (Kano is also the largest city in Northern "
+"Nigeria.) What makes Kano different to other computers? All of the ideas in "
+"its brain are open for you to see. Just visit <b>github.com/KanoComputing</"
+"b> to see the code. Kano can also change forms… You can turn it into a "
+"robot, server, radio, and more. Visit <b>world.kano.me/projects</b> for "
+"powerup ideas. Want a look inside Kano HQ? Hang with our wizards at <b>blog."
+"kano.me</b>"
+msgstr ""
+"Dein Computer heißt \"Kano\" - nach Kanō Jigorō. Der japanische Lehrer ist "
+"der Erfinder der Kampfkunst Judo. Sein Prinzip: Maximale Wirkung bei einem "
+"Minimum an Aufwand. Das griechische Verb Kano heißt \"ich mache\". (Und Kano "
+"heißt auch die größte Stadt im Norden Nigerias.) Was unterscheidet Deinen "
+"Kano von anderen Computern? Du kannst Dir alles ansehen, was in seinem Gehirn "
+"passiert. Auf <b>github.com/KanoComputing</b> findest Du den Code. Dein Kano "
+"kann seine Form verändern… Du kannst aus ihm einen Roboter, einen Server, "
+"ein Radio und vieles mehr machen. Einige Ideen dafür findest Du auf <b>world."
+"kano.me/projects</b>. Und auf <b>blog.kano.me</b> lernst Du die Leute hinter "
+"Kano kennen."
+
+#: ../kano_updater_gui/text.py:84
+msgid ""
+"Kano OS is an operating system, which means it connects all the programs "
+"together. This OS is based on Linux, whose code is open — that means that "
+"it's free for anyone to download, change or even sell. Its code is written "
+"by hobbyists and makers worldwide, not just professionals. Kano uses Debian, "
+"a fun and powerful \"distribution\" of Linux which the International Space "
+"Station also uses to run its robotic systems — to keep the astronauts from "
+"losing their lunch!"
+msgstr ""
+"Kano OS ist ein Betriebssystem. Das heißt, es stellt Dir alle nötigen "
+"Programme startklar zu Verfügung. Es basiert auf Linux. Linux ist Open "
+"Source Software — es ist kostenlos und jeder kann es herunterladen, "
+"verändern und sogar verkaufen. Der Linux-Code wird von Bastlern weltweit "
+"geschrieben, nicht nur von Profis. Kano verwendet Debian, eine tolle und "
+"beliebte Linux-\"Distribution\", die z.B. auf der Internationale Raumstation "
+"ISS die Robotersysteme steuert, damit die Astronauten ihr Essen nicht "
+"verlieren!"
+
+#: ../kano_updater_gui/text.py:95
+msgid ""
+"We're almost done! With your Kano computer, you'll make awesome games, code "
+"your own music, stream videos around your house, tell stories, and much "
+"more. Your computer is open, and its powers are at your command. If you want "
+"to get new cool projects from us each week, join the community at"
+msgstr ""
+"Gleich sind wir fertig! Mit Deinem Kano-Computer wirst Du großartige Spiele, "
+"Programme, Deine eigene Musik machen. Du kannst Videos im Haus streamen, "
+"Geschichten erzählen und noch viel mehr. Dein Computer ist offen und er "
+"steht Dir zur Verfügung. Wenn Du coole neue Projekte von uns kriegen willst, "
+"schau doch mal rein unter"
+
+#: ../kano_updater_gui/text.py:102
+msgid ""
+"Your Kano will now reboot!\n"
+"\n"
+"See you in a while…"
+msgstr ""
+"Dein Kano-Computer wird jetzt neu starten!\n"
+"\n"
+"Bis gleich…"
+
+#: ../kano_updater_gui/header.py:113
+msgid "Do not disconnect your Kano"
+msgstr "Schalte Deinen Kano nicht ab"
+
+#: ../kano_updater_gui/header.py:115
+msgid "Please stand by"
+msgstr "Bitte warten"
+
+#: ../lxpanel-plugin/kano_updater.c:33 ../lxpanel-plugin/kano_updater.c:243
+#: ../lxpanel-plugin/kano_updater.c:338
+msgid "Kano Updater"
+msgstr "Kano Updater"
+
+#: ../lxpanel-plugin/kano_updater.c:249
+msgid "Update your system"
+msgstr "Updates für Dein System"
+
+#: ../lxpanel-plugin/kano_updater.c:255
+msgid "No updates found"
+msgstr "Keine Updates gefunden"
+
+#: ../lxpanel-plugin/kano_updater.c:260
+msgid "Check again"
+msgstr "Nochmal prüfen"
+
+#: ../lxpanel-plugin/kano_updater.c:339
+msgid "A reminder to keep your Kano OS up-to-date."
+msgstr "Hält Kano OS auf dem neuesten Stand."

--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-19 14:28+0100\n"
+"POT-Creation-Date: 2015-02-23 14:02+0100\n"
 "PO-Revision-Date: 2015-02-13 17:16+0100\n"
 "Last-Translator:  <kontakt@hanno.de>\n"
 "Language-Team: German <kontakt@hanno.de>\n"
@@ -18,9 +18,93 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: ../bin/check-for-updates:46
+msgid "New Update"
+msgstr "Neues Update"
+
+#: ../bin/check-for-updates:64
+msgid "Time to update!"
+msgstr "Zeit für ein Update!"
+
+#: ../bin/check-for-updates:64
+msgid "Take a break! Updating takes about 15 minutes"
+msgstr "Mach mal Pause! Das Update dauert etwa 15 Minuten"
+
+#: ../bin/check-for-updates:67 ../bin/kano-updater:111
+msgid "Update now"
+msgstr "Jetzt updaten"
+
+#: ../bin/check-for-updates:69 ../bin/kano-updater:112
+msgid "Later"
+msgstr "Später"
+
+#: ../bin/kano-updater:70
+msgid "You need to run kano-updater from a GUI session!"
+msgstr "Du musst kano-updater aus der GUI heraus starten!"
+
+#: ../bin/kano-updater:93
+msgid ""
+"Unfortunately, your version of Kano OS is too old to be updated through the "
+"updater."
+msgstr ""
+"Leider ist Dein Kano OS zu alt, um es mit dem Updater auf den neuesten Stand "
+"zu bringen."
+
+#: ../bin/kano-updater:95
+msgid "You will need to download the image of the OS and reflash your SD card."
+msgstr ""
+"Bitte lade das neueste Image von Kano OS herunter und installiere es mit "
+"einer SD-Karte."
+
+#: ../bin/kano-updater:99 ../bin/kano-updater:115 ../bin/kano-updater:197
+#: ../bin/kano-updater:212 ../lxpanel-plugin/kano_updater.c:33
+#: ../lxpanel-plugin/kano_updater.c:243 ../lxpanel-plugin/kano_updater.c:338
+msgid "Kano Updater"
+msgstr "Kano Updater"
+
+#: ../bin/kano-updater:109
+msgid "Let's update!"
+msgstr "Ein Update!"
+
+#: ../bin/kano-updater:110
+msgid "Your Kano is about to get better"
+msgstr "Dein Kano wird jetzt verbessert"
+
+#: ../bin/kano-updater:195 ../kano_updater/utils.py:328
+msgid "Error!"
+msgstr "Fehler!"
+
+#: ../bin/kano-updater:195
+msgid "Internet connection lost!"
+msgstr "Keine Internet-Verbindung!"
+
+#: ../bin/kano-updater:210
+msgid "Error with downloading packages!"
+msgstr "Konnte Pakete nicht herunterladen!"
+
 #: ../bin/kano-updater-gui:97
 msgid "Updater"
 msgstr "Updater"
+
+#: ../kano_updater/utils.py:65
+msgid ""
+"We had a problem with the Update. Make sure you are connected to the "
+"Internet, and give it another go.\n"
+"\n"
+"If you still have problems, we can help at http://help.kano.me"
+msgstr ""
+"Beim Update gab es ein Problem. Bitte prüfe die Internet-Verbindung und "
+"versuche es noch einmal.\n"
+"\n"
+"Falls Du nicht weiterkommst, können wir Dir bei http://help.kano.me helfen."
+
+#: ../kano_updater/utils.py:69
+msgid "Update error"
+msgstr "Update-Fehler"
+
+#: ../kano_updater/utils.py:329
+msgid "kano-updater must be executed with root privileges"
+msgstr "kano-updater benötigt Root-Rechte"
 
 #: ../kano_updater_gui/text.py:12
 msgid "1. Downloading…"
@@ -171,12 +255,12 @@ msgstr ""
 "der Erfinder der Kampfkunst Judo. Sein Prinzip: Maximale Wirkung bei einem "
 "Minimum an Aufwand. Das griechische Verb Kano heißt \"ich mache\". (Und Kano "
 "heißt auch die größte Stadt im Norden Nigerias.) Was unterscheidet Deinen "
-"Kano von anderen Computern? Du kannst Dir alles ansehen, was in seinem Gehirn "
-"passiert. Auf <b>github.com/KanoComputing</b> findest Du den Code. Dein Kano "
-"kann seine Form verändern… Du kannst aus ihm einen Roboter, einen Server, "
-"ein Radio und vieles mehr machen. Einige Ideen dafür findest Du auf <b>world."
-"kano.me/projects</b>. Und auf <b>blog.kano.me</b> lernst Du die Leute hinter "
-"Kano kennen."
+"Kano von anderen Computern? Du kannst Dir alles ansehen, was in seinem "
+"Gehirn passiert. Auf <b>github.com/KanoComputing</b> findest Du den Code. "
+"Dein Kano kann seine Form verändern… Du kannst aus ihm einen Roboter, einen "
+"Server, ein Radio und vieles mehr machen. Einige Ideen dafür findest Du auf "
+"<b>world.kano.me/projects</b>. Und auf <b>blog.kano.me</b> lernst Du die "
+"Leute hinter Kano kennen."
 
 #: ../kano_updater_gui/text.py:84
 msgid ""
@@ -227,11 +311,6 @@ msgstr "Schalte Deinen Kano nicht ab"
 #: ../kano_updater_gui/header.py:115
 msgid "Please stand by"
 msgstr "Bitte warten"
-
-#: ../lxpanel-plugin/kano_updater.c:33 ../lxpanel-plugin/kano_updater.c:243
-#: ../lxpanel-plugin/kano_updater.c:338
-msgid "Kano Updater"
-msgstr "Kano Updater"
 
 #: ../lxpanel-plugin/kano_updater.c:249
 msgid "Update your system"


### PR DESCRIPTION
Essentially the same as https://github.com/KanoComputing/kano-updater/pull/63.

The differences being:
 - Rebased on the `master`'s `HEAD` to resolve conflict
 - Removed commit https://github.com/hzulla/kano-updater/commit/8d9ceab3ef4e0a94f00a5755c2eb9e7ba9843688 because this functionality has been moved into `kano-toolset` and thus there is now a dependency on `v1.3-10` (and https://github.com/hzulla/kano-updater/commit/43d492728fde4888e59e1a8fb301bdc03f2b8ef2 which removes something in the aforementioned commit)
 - Bumped the version to allow translation functionality dependent dependencies :-P
 - Added copyright information to the German translation and to the `Makefile` to auto-generate this information

@hzulla Any objections?

@Ealdwulf @skarbat @carolineclark @pazdera @convolu @alex5imon Any last comments before we merge?
