### PR TITLE
Update pip

### DIFF
--- a/bin/kano-updater
+++ b/bin/kano-updater
@@ -13,7 +13,7 @@ Usage:
   kano-updater check
   kano-updater download
   kano-updater install [--gui]
-  kano-updater install-pip
+  kano-updater update-pip
   kano-updater reset <state>
   kano-updater [-f] [-n]
 
@@ -112,7 +112,7 @@ def main():
     msg = _('Administrator priviledges are required to perform this operation')
     enforce_root("{}: {}".format(_('ERROR'), msg))
 
-    if args['install-pip']:
+    if args['update-pip']:
         # This subcommand is intended to be run from peldins to actually
         # install the pip packages on to the image in the first place.
         supress_output(install_pip)

--- a/kano_updater/commands/download.py
+++ b/kano_updater/commands/download.py
@@ -5,8 +5,6 @@
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 #
 
-import pip
-
 from kano.network import is_internet
 
 from kano_updater.paths import PIP_PACKAGES_LIST
@@ -121,6 +119,10 @@ def _cache_pip_packages(progress):
     # The `--no-install` parameter has been deprecated in pip. However, the
     # version of pip in wheezy doesn't yet support the new approach which is
     # supposed to provide the same behaviour.
+    #
+    # pip is imported locally because it takes very long time to do,
+    # for some odd reason
+    import pip
     supress_output(pip.main, ['install', '--upgrade', '--no-install', '-r',
                               PIP_PACKAGES_LIST])
 

--- a/kano_updater/commands/install.py
+++ b/kano_updater/commands/install.py
@@ -5,7 +5,6 @@
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 #
 
-import pip
 import sys
 import time
 
@@ -186,4 +185,7 @@ def install_deb_packages(progress):
 
 
 def install_pip_packages(progress):
+    # pip is imported locally because it takes very long do to,
+    # for some odd reason
+    import pip
     supress_output(pip.main, ['install', '--upgrade', '-r', PIP_PACKAGES_LIST])


### PR DESCRIPTION
Importing pip locally and changing the `install-pip` to `update-pip`, because it doesn't make much sense to run pip install docopt and then install-pip.

@tombettany 