### PR TITLE
Update downloaded GUI: Add update downloaded GUI

### DIFF
--- a/kano_updater/ui/install_window.py
+++ b/kano_updater/ui/install_window.py
@@ -46,10 +46,6 @@ class InstallWindow(Gtk.Window):
         # self.connect('delete-event', self.close_window)
 
         self._start_install()
-        """
-        self.update_progress(27, 'Updating the updater',
-                             'Running The Preupdate Scripts...')
-        """
 
     def _start_install(self):
         progress = GtkProgress(self)
@@ -73,8 +69,11 @@ class InstallWindow(Gtk.Window):
 
     def update_progress(self, percent, msg, sub_msg=''):
         self._install_screen.update_progress(percent, msg, sub_msg)
-        if percent == 100:
-            time.sleep(1)
+
+        # FIXME Progress to next with the done
+        if percent == 100 and sub_msg in [_('Update completed'),
+                                          _('No updates to download')]:
+
             self._done_install()
 
     def error(self, msg):

--- a/kano_updater/ui/main.py
+++ b/kano_updater/ui/main.py
@@ -12,13 +12,13 @@ from gi.repository import GLib, Gdk, Gtk
 from kano_updater.commands.check import check_for_updates
 
 def launch_install_gui():
-    from kano_updater.ui.install_window import InstallWindow
+    from kano_updater.ui.available_window import UpdatesDownloadedWindow
 
     GLib.threads_init()
     Gdk.threads_init()
     Gdk.threads_enter()
 
-    win = InstallWindow()
+    win = UpdatesDownloadedWindow()
     win.show()
     Gtk.main()
 
@@ -31,16 +31,3 @@ def launch_check_gui():
         win = UpdatesAvailableWindow()
         win.show()
         Gtk.main()
-
-def launch_downloaded_gui():
-    from kano_updater.ui.available_window import UpdatesDownloadedWindow
-
-    GLib.threads_init()
-    Gdk.threads_init()
-    Gdk.threads_enter()
-
-    win = UpdatesDownloadedWindow()
-    win.show()
-    Gtk.main()
-
-    Gdk.threads_leave()


### PR DESCRIPTION
Missed some things with https://github.com/KanoComputing/kano-updater/pull/75

Other half of c00736b3a9b0ee0e14deadef50ba6d0eb902613e
Move common functionality of the update available and update downloaded
dialogs into a base class. Implement the update downloaded window. Fix
rebooting image to stop after one loop and actually reboot when it
happens. Fix the install screen not progressing when the download is
complete.