### PR TITLE
Remove check-for-updates entry in the sudoers file

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -14,7 +14,6 @@ case "$1" in
         # Create custom sudoers file
         echo "%sudo   ALL=(root) NOPASSWD: /usr/bin/kano-updater" > $TMP_FILE
         echo "%sudo   ALL=(root) NOPASSWD: /usr/bin/expand-rootfs" >> $TMP_FILE
-        echo "%sudo   ALL=(root) NOPASSWD: /usr/bin/check-for-updates" >> $TMP_FILE
 
         # The owner and group for the sudoers file must both be 0
         chown root:root $TMP_FILE


### PR DESCRIPTION
check-for-updates no longer exists so it is unnecessary to keep the
entry in the sudoers file.