### PR TITLE
Update the CLI interface

### DIFF
--- a/bin/kano-updater
+++ b/bin/kano-updater
@@ -14,8 +14,8 @@ Usage:
   kano-updater download [--low-prio]
   kano-updater install [--gui [--no-confirm] [--splash-pid <pid>]]
   kano-updater set-state <state>
-  kano-updater boot-check [--check-for-updates]
-  kano-updater relaunch-countdown <parent-pid>
+  kano-updater clean
+  kano-updater ui (relaunch-splash <parent-pid> | boot-window)
   kano-updater [-f] [-n]
 
 Options:
@@ -51,6 +51,7 @@ from kano_updater.os_version import TARGET_VERSION
 from kano_updater.commands.download import download
 from kano_updater.commands.install import install
 from kano_updater.commands.check import check_for_updates
+from kano_updater.commands.clean import clean
 from kano_updater.progress import CLIProgress, Relaunch
 from kano_updater.status import UpdaterStatus
 from kano_updater.utils import make_low_prio, install_docopt, is_running, \
@@ -108,13 +109,18 @@ def main():
         status = UpdaterStatus.get_instance()
         status.state = args['<state>']
         status.save()
-    elif args['boot-check']:
-        from kano_updater.ui.main import launch_boot_check_gui
-        launch_boot_check_gui(args['--check-for-updates'])
-    elif args['relaunch-countdown']:
-        from kano_updater.ui.main import launch_relaunch_countdown_gui
-        launch_relaunch_countdown_gui(int(args['<parent-pid>']))
+    elif args['clean']:
+        clean()
+    elif args['ui']:
+        if args['relaunch-splash']:
+            from kano_updater.ui.main import launch_relaunch_countdown_gui
+            launch_relaunch_countdown_gui(int(args['<parent-pid>']))
+        elif args['boot-window']:
+            from kano_updater.ui.main import launch_boot_gui
+            launch_boot_gui()
     else:
+        clean()
+
         progress = CLIProgress()
 
         if args['download']:

--- a/kano_updater/commands/clean.py
+++ b/kano_updater/commands/clean.py
@@ -11,7 +11,7 @@ from kano_updater.status import UpdaterStatus
 # from kano_updater.ui.
 
 
-def boot_check():
+def clean():
     status = UpdaterStatus.get_instance()
 
     old_status = status.state

--- a/kano_updater/ui/main.py
+++ b/kano_updater/ui/main.py
@@ -16,10 +16,10 @@ from kano.utils import run_cmd
 from kano.logging import logger
 
 from kano_updater.commands.check import check_for_updates
-from kano_updater.commands.boot_check import boot_check
+from kano_updater.commands.clean import clean
 from kano_updater.progress import Relaunch
 from kano_updater.status import UpdaterStatus
-from kano_updater.utils import show_relaunch_countdown
+from kano_updater.utils import show_relaunch_splash
 
 
 relaunch_required_flag = False
@@ -31,7 +31,7 @@ def relaunch_required():
     global splash_pid
 
     relaunch_required_flag = True
-    splash_pid = show_relaunch_countdown()
+    splash_pid = show_relaunch_splash()
 
 
 def launch_install_gui(confirm=True, splash_pid=None):
@@ -65,15 +65,12 @@ def launch_check_gui(min_time_between_checks=0):
         Gtk.main()
 
 
-def launch_boot_check_gui(check_for_updates=False):
-    if check_for_updates:
-        launch_check_gui(168)
-
-    old_status = boot_check()
+def launch_boot_gui():
+    old_status = clean()
     if old_status == UpdaterStatus.UPDATES_INSTALLED:
         # TODO: Implement the updater dialog properly
-        title = "Kano OS was updated"
-        text = "The update completed successfully. Enjoy the new version!"
+        title = 'Kano OS was updated'
+        text = 'The update completed successfully. Enjoy the new version!'
         run_cmd("kano-dialog title=\"{}\" description=\"{}\"".format(title,
                                                                      text))
 

--- a/kano_updater/utils.py
+++ b/kano_updater/utils.py
@@ -134,8 +134,8 @@ def migrate_repository(apt_file, old_repo, new_repo):
 def _handle_sigusr1(signum, frame):
     pass
 
-def show_relaunch_countdown():
-    cmd = ["kano-updater", "relaunch-countdown", str(os.getpid())]
+def show_relaunch_splash():
+    cmd = ["kano-updater", "ui", "relaunch-splash", str(os.getpid())]
     p = subprocess.Popen(cmd, shell=False)
 
     # register a handler for SIGUSR1


### PR DESCRIPTION
Split the `boot-check` command into a new clean command which corrects
the state of the status file if it is left unclean and move the
boot check window (along with the splash relaunch) into a `ui`
subcommand.

@pazdera I'm sure that I've missed something but this is a start