### PR TITLE
Installing requests security module, to remove further warnings

### DIFF
--- a/python_modules
+++ b/python_modules
@@ -1,5 +1,6 @@
 pip
 ping
+requests[security]
 requests
 tzupdate
 pam


### PR DESCRIPTION
 * This installation should remove further complains from pip:
   "InsecurePlatformWarning: A true SSLContext object is not available"