### PR TITLE
Fixing pip requests installation

### DIFF
--- a/python_modules
+++ b/python_modules
@@ -1,7 +1,6 @@
 pip
 ping
 requests[security]
-requests
 tzupdate
 pam
 python-slugify


### PR DESCRIPTION
 * Square brackets name a dependency package,
   so removing the additional line to install "requests",
   because pip complains with an error, saying it is covered
   by the previous line.

cc @Ealdwulf 