### PR TITLE
bin: Adding the first-boot subcommand

### DIFF
--- a/bin/kano-updater
+++ b/bin/kano-updater
@@ -14,6 +14,7 @@ Usage:
   kano-updater download [--low-prio]
   kano-updater install [--gui [--no-confirm] [--splash-pid <pid>]]
   kano-updater set-state <state>
+  kano-updater first-boot
   kano-updater clean
   kano-updater ui (relaunch-splash <parent-pid> | boot-window)
   kano-updater [-f] [-n]
@@ -123,6 +124,13 @@ def main():
         elif args['boot-window']:
             from kano_updater.ui.main import launch_boot_gui
             launch_boot_gui()
+    elif args['first-boot']:
+        # spoof the last_check timestamp to six days ago so the user won't
+        # be prompted to update in the first day after boot
+        status = UpdaterStatus.get_instance()
+        six_days_ago = time.time() - 6 * 24 * 60 * 60
+        status.last_check = status.last_update = six_days_ago
+        status.save()
     else:
         clean()
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-updater (2.0.0-2) unstable; urgency=low
+
+  * Adding new subcommand: first-boot to be used from kano-uixinit
+
+ -- Team Kano <dev@kano.me>  Wed, 29 Apr 2015 16:00:00 +0000
+
 kano-updater (2.0.0-1) unstable; urgency=low
 
   * Keeping the version in sync with the OS version.


### PR DESCRIPTION
This should be used from kano-uixinit at the end of the init flow to
make sure the user isn't prompted for update during the first 24 hours
from creating his account.

Needs a change in kano-uixinit which will be ready shortly.

cc @tombettany @alex5imon 