### PR TITLE
pip: Quoting package names to avoid shell errors

### DIFF
--- a/kano_updater/commands/download.py
+++ b/kano_updater/commands/download.py
@@ -148,7 +148,7 @@ def _cache_pip_packages(progress):
         # The `--no-install` parameter has been deprecated in pip. However, the
         # version of pip in wheezy doesn't yet support the new approach which
         # is supposed to provide the same behaviour.
-        args = "install --upgrade --no-install {}".format(pkg)
+        args = "install --upgrade --no-install '{}'".format(pkg)
         success = run_pip_command(args)
 
         # TODO: abort the install?

--- a/kano_updater/commands/install.py
+++ b/kano_updater/commands/install.py
@@ -224,7 +224,7 @@ def install_pip_packages(progress):
     for pkg in packages:
         progress.next_step(phase_name, "Installing {}".format(pkg))
 
-        success = run_pip_command("install --upgrade {}".format(pkg))
+        success = run_pip_command("install --upgrade '{}'".format(pkg))
 
         if not success:
             msg = "Installing the '{}' pip package failed".format(pkg)


### PR DESCRIPTION
These can arise from special characters such as (>, < and others).

cc @Ealdwulf @alex5imon 

Related to: https://github.com/KanoComputing/peldins/issues/1803