### PR TITLE
updater-notifications: New notifications style

### DIFF
--- a/bin/kano-updater
+++ b/bin/kano-updater
@@ -165,11 +165,13 @@ def main():
                     # Return if the check happened too early.
                     return 2
 
-            if args['--gui']:
-                from kano_updater.ui.main import launch_check_gui
-                updates_available = launch_check_gui()
-            else:
-                updates_available = check_for_updates(progress=progress)
+            # There used to be a dialog pop up if an update was found
+            # that we had removed (see the commented out lines bellow).
+            #if args['--gui']:
+            #    from kano_updater.ui.main import launch_check_gui
+            #    updates_available = launch_check_gui()
+            #else:
+            updates_available = check_for_updates(progress=progress)
 
             if updates_available:
                 logger.info(_('Updates available.'))

--- a/lxpanel-plugin/kano_updater.c
+++ b/lxpanel-plugin/kano_updater.c
@@ -70,7 +70,22 @@
 		"\"image\": \"/usr/share/kano-updater/images/notification-updates-available.png\"," \
 		"\"sound\": null," \
 		"\"type\": \"small\"," \
-		"\"command\": \"sudo kano-updater download\"" \
+		"\"button1_label\": \"DOWNLOAD\"," \
+		"\"button1_colour\": \"#7abd48\"," \
+		"\"button1_hover\": \"#84cc4e\"," \
+		"\"button1_command\": \"sudo kano-updater download\"," \
+		"\"button2_label\": \"LATER\"," \
+		"\"button2_colour\": \"#e67677\"," \
+		"\"button2_hover\": \"#f27c7e\"" \
+	"}\n"
+
+#define UPDATES_DOWNLOADING_NOTIFICATION \
+	"{" \
+		"\"title\": \"Download Started\"," \
+		"\"byline\": \"The updates are downloading.\"," \
+		"\"image\": \"/usr/share/kano-updater/images/notification-updates-available.png\"," \
+		"\"sound\": null," \
+		"\"type\": \"small\"," \
 	"}\n"
 
 #define UPDATES_DOWNLOADED_NOTIFICATION \
@@ -80,7 +95,13 @@
 		"\"image\": \"/usr/share/kano-updater/images/notification-updates-downloaded.png\"," \
 		"\"sound\": null," \
 		"\"type\": \"small\"," \
-		"\"command\": \"sudo kano-updater install --gui\"" \
+		"\"button1_label\": \"RESTART\"," \
+		"\"button1_colour\": \"#7abd48\"," \
+		"\"button1_hover\": \"#84cc4e\"," \
+		"\"button1_command\": \"sudo kano-updater install --gui\"," \
+		"\"button2_label\": \"LATER\"," \
+		"\"button2_colour\": \"#e67677\"," \
+		"\"button2_hover\": \"#f27c7e\"" \
 	"}\n"
 
 typedef struct {
@@ -327,6 +348,9 @@ static gboolean update_status(kano_updater_plugin_t *plugin_data)
 	} else if (IS_IN_STATE(plugin_data, "downloading-updates")) {
 		gtk_image_set_from_file(GTK_IMAGE(plugin_data->icon),
 						DOWNLOADING_UPDATES_ICON_FILE);
+
+		if (g_strcmp0(plugin_data->prev_state, plugin_data->state) != 0)
+			show_notification(UPDATES_DOWNLOADING_NOTIFICATION);
 	} else if (IS_IN_STATE(plugin_data, "updates-downloaded")) {
 		gtk_image_set_from_file(GTK_IMAGE(plugin_data->icon),
 						UPDATES_DOWNLOADED_ICON_FILE);

--- a/lxpanel-plugin/kano_updater.c
+++ b/lxpanel-plugin/kano_updater.c
@@ -95,7 +95,7 @@
 		"\"button1_label\": \"RESTART\"," \
 		"\"button1_colour\": \"#7abd48\"," \
 		"\"button1_hover\": \"#84cc4e\"," \
-		"\"button1_command\": \"sudo kano-updater install --gui\"," \
+		"\"button1_command\": \"sudo kano-updater install --gui --no-confirm\"," \
 		"\"button2_label\": \"LATER\"," \
 		"\"button2_colour\": \"#e67677\"," \
 		"\"button2_hover\": \"#f27c7e\"" \

--- a/lxpanel-plugin/kano_updater.c
+++ b/lxpanel-plugin/kano_updater.c
@@ -68,7 +68,6 @@
 		"\"title\": \"Get new powers\"," \
 		"\"byline\": \"Click here to download updates\"," \
 		"\"image\": \"/usr/share/kano-updater/images/notification-updates-available.png\"," \
-		"\"sound\": null," \
 		"\"type\": \"small\"," \
 		"\"button1_label\": \"DOWNLOAD\"," \
 		"\"button1_colour\": \"#7abd48\"," \
@@ -84,7 +83,6 @@
 		"\"title\": \"Download Started\"," \
 		"\"byline\": \"The updates are downloading.\"," \
 		"\"image\": \"/usr/share/kano-updater/images/notification-updates-available.png\"," \
-		"\"sound\": null," \
 		"\"type\": \"small\"," \
 	"}\n"
 
@@ -93,7 +91,6 @@
 		"\"title\": \"Download Complete\"," \
 		"\"byline\": \"Time to power up!\"," \
 		"\"image\": \"/usr/share/kano-updater/images/notification-updates-downloaded.png\"," \
-		"\"sound\": null," \
 		"\"type\": \"small\"," \
 		"\"button1_label\": \"RESTART\"," \
 		"\"button1_colour\": \"#7abd48\"," \


### PR DESCRIPTION
The updater notifications will now use the new OS X style notification
buttons. This commit also adds a new notifications to indicate the
download started.

Related to: https://github.com/KanoComputing/peldins/issues/1841 https://github.com/KanoComputing/kano-widgets/pull/17

cc @tombettany @alex5imon 