### PR TITLE
update_home_folders_from_skel: Run in a try

### DIFF
--- a/kano_updater/auxiliary_tasks.py
+++ b/kano_updater/auxiliary_tasks.py
@@ -26,7 +26,6 @@ def run_aux_tasks(progress):
 
     progress.start('updating-home-folders')
 
-    # TODO: We might want to keep this in install()
     try:
         update_home_folders_from_skel()
     except Exception as e:

--- a/kano_updater/auxiliary_tasks.py
+++ b/kano_updater/auxiliary_tasks.py
@@ -5,6 +5,8 @@
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 #
 
+import sys
+import traceback
 
 from kano_updater.utils import update_home_folders_from_skel
 from kano.utils import run_cmd_log
@@ -23,8 +25,15 @@ def run_aux_tasks(progress):
     )
 
     progress.start('updating-home-folders')
+
     # TODO: We might want to keep this in install()
-    update_home_folders_from_skel()
+    try:
+        update_home_folders_from_skel()
+    except Exception as e:
+        logger.error("Updating home folders failed. See the traceback bellow:")
+        _, _, tb = sys.exc_info()
+        for tb_line in traceback.format_tb(tb):
+            logger.error(tb_line)
 
     progress.start('refreshing-kdesk')
     _refresh_kdesk()


### PR DESCRIPTION
This will stop the updater from freezing and log the traceback, should there be a problem in the home directory.

Related to: https://github.com/KanoComputing/peldins/issues/1820

cc @alex5imon @tombettany @skarbat @Ealdwulf 