### PR TITLE
Froze futures module version

### DIFF
--- a/python_modules
+++ b/python_modules
@@ -7,4 +7,4 @@ python-slugify
 decorator
 youtube_dl<2015.04.26
 docopt
-futures
+futures==2.1.4


### PR DESCRIPTION
The Sentry module seems to be the only package that needs the futures module, so we're freezing the version.  Later versions of the futures modules seem to break the sentry module, which breaks the Ultimate Parental Control.