### PR TITLE
Notifications: Suppress messages when the GUI is running

### DIFF
--- a/bin/kano-updater
+++ b/bin/kano-updater
@@ -63,9 +63,17 @@ from kano_updater.utils import make_low_prio, install_docopt, is_running, \
 def clean_up():
     remove_pid_file()
 
+    status = UpdaterStatus.get_instance()
+    status.is_gui_running = False
+    status.save()
+
 
 def run_install(gui=False, confirm=True, splash_pid=None):
     if gui:
+        status = UpdaterStatus.get_instance()
+        status.is_gui_running = True
+        status.save()
+
         from kano_updater.ui.main import launch_install_gui
 
         try:

--- a/bin/kano-updater
+++ b/bin/kano-updater
@@ -43,6 +43,7 @@ if __name__ == '__main__' and __package__ is None:
     else:
         locale_path = None
 
+import kano.notifications as notifications
 from kano.utils import enforce_root
 from kano.logging import logger
 
@@ -67,9 +68,13 @@ def clean_up():
     status.is_gui_running = False
     status.save()
 
+    notifications.resume()
+
 
 def run_install(gui=False, confirm=True, splash_pid=None):
     if gui:
+        notifications.pause()
+
         status = UpdaterStatus.get_instance()
         status.is_gui_running = True
         status.save()

--- a/kano_updater/commands/clean.py
+++ b/kano_updater/commands/clean.py
@@ -32,6 +32,8 @@ def clean():
         msg = "The status was changed to: {}".format(status.state)
         logger.debug(msg)
 
+    status.is_gui_running = False
+
     status.save()
 
     return old_status

--- a/kano_updater/status.py
+++ b/kano_updater/status.py
@@ -55,6 +55,7 @@ class UpdaterStatus(object):
         self._state = self.NO_UPDATES
         self._last_check = 0
         self._last_update = 0
+        self._is_gui_running = False
 
         ensure_dir(os.path.dirname(self._status_file))
         if not os.path.exists(self._status_file):
@@ -81,11 +82,15 @@ class UpdaterStatus(object):
             self._last_update = data['last_update']
             self._last_check = data['last_check']
 
+            if 'is_gui_running' in data:
+                self._is_gui_running = (data['is_gui_running'] == 1)
+
     def save(self):
         data = {
             'state': self._state,
             'last_update': self._last_update,
-            'last_check': self._last_check
+            'last_check': self._last_check,
+            'is_gui_running': 1 if self._is_gui_running else 0
         }
 
         with open(self._status_file, 'w') as status_file:
@@ -129,3 +134,20 @@ class UpdaterStatus(object):
             raise UpdaterStatusError(msg)
 
         self._last_check = value
+
+    """
+    # -- is_gui_running
+
+    Stored internally as a boolean but saved to file as 0/1 to interface with C
+    """
+    @property
+    def is_gui_running(self):
+        return self._is_gui_running
+
+    @is_gui_running.setter
+    def is_gui_running(self, value):
+        if not isinstance(value, bool):
+            msg = "'is_gui_running' must be a boolean value."
+            raise UpdaterStatusError(msg)
+
+        self._is_gui_running = value

--- a/lxpanel-plugin/kano_updater.c
+++ b/lxpanel-plugin/kano_updater.c
@@ -310,23 +310,23 @@ static gboolean read_status(kano_updater_plugin_t *plugin_data)
 	if (json_value_get_type(root_value) == JSONObject) {
 		root = json_value_get_object(root_value);
 
-                // Sanity check for json expected format
-                char *state=(char *)json_object_get_string(root, "state");
-                if (state) {
-                    SET_STATE(plugin_data, state);
+		// Sanity check for json expected format
+		char *state = (char *)json_object_get_string(root, "state");
+		if (state) {
+			SET_STATE(plugin_data, state);
 
-                    plugin_data->last_check = (int) 
-                        json_object_get_number(root, "last_check");
+			plugin_data->last_check = (int)
+				json_object_get_number(root, "last_check");
 
-                    plugin_data->last_update = (int) 
-                        json_object_get_number(root, "last_update");
+			plugin_data->last_update = (int)
+				json_object_get_number(root, "last_update");
 
-                    plugin_data->is_gui_running = (int)
-                        json_object_get_number(root, "is_gui_running");
+			plugin_data->is_gui_running = (int)
+				json_object_get_number(root, "is_gui_running");
 
-                    json_value_free(root_value);
-                    return TRUE;
-                }
+			json_value_free(root_value);
+			return TRUE;
+		}
 	}
 
 	json_value_free(root_value);

--- a/lxpanel-plugin/kano_updater.c
+++ b/lxpanel-plugin/kano_updater.c
@@ -109,6 +109,7 @@ typedef struct {
 	gchar *prev_state;
 	int last_update;
 	int last_check;
+	int is_gui_running;
 
 	GtkWidget *icon;
 
@@ -141,6 +142,7 @@ static GtkWidget *plugin_constructor(LXPanel *panel, config_setting_t *settings)
 	plugin_data->prev_state = g_new0(gchar, MAX_STATE_LENGTH);
 	plugin_data->last_update = 0;
 	plugin_data->last_check = 0;
+	plugin_data->is_gui_running = FALSE;
 
 	GtkWidget *icon = gtk_image_new_from_file(NO_UPDATES_ICON_FILE);
 	plugin_data->icon = icon;
@@ -319,6 +321,9 @@ static gboolean read_status(kano_updater_plugin_t *plugin_data)
                     plugin_data->last_update = (int) 
                         json_object_get_number(root, "last_update");
 
+                    plugin_data->is_gui_running = (int)
+                        json_object_get_number(root, "is_gui_running");
+
                     json_value_free(root_value);
                     return TRUE;
                 }
@@ -340,19 +345,22 @@ static gboolean update_status(kano_updater_plugin_t *plugin_data)
 		gtk_image_set_from_file(GTK_IMAGE(plugin_data->icon),
 						  UPDATES_AVAILABLE_ICON_FILE);
 
-		if (g_strcmp0(plugin_data->prev_state, plugin_data->state) != 0)
+		if (g_strcmp0(plugin_data->prev_state, plugin_data->state) != 0 &&
+			!plugin_data->is_gui_running)
 			show_notification(UPDATES_AVAILABLE_NOTIFICATION);
 	} else if (IS_IN_STATE(plugin_data, "downloading-updates")) {
 		gtk_image_set_from_file(GTK_IMAGE(plugin_data->icon),
 						DOWNLOADING_UPDATES_ICON_FILE);
 
-		if (g_strcmp0(plugin_data->prev_state, plugin_data->state) != 0)
+		if (g_strcmp0(plugin_data->prev_state, plugin_data->state) != 0 &&
+			!plugin_data->is_gui_running)
 			show_notification(UPDATES_DOWNLOADING_NOTIFICATION);
 	} else if (IS_IN_STATE(plugin_data, "updates-downloaded")) {
 		gtk_image_set_from_file(GTK_IMAGE(plugin_data->icon),
 						UPDATES_DOWNLOADED_ICON_FILE);
 
-		if (g_strcmp0(plugin_data->prev_state, plugin_data->state) != 0)
+		if (g_strcmp0(plugin_data->prev_state, plugin_data->state) != 0 &&
+			!plugin_data->is_gui_running)
 			show_notification(UPDATES_DOWNLOADED_NOTIFICATION);
 	} else {
 		gtk_image_set_from_file(GTK_IMAGE(plugin_data->icon),


### PR DESCRIPTION
KanoComputing/peldins#1902
When the updater is in full-screen install mode, it will change its
status file to account for the progress made in the install. This,
however, generates notifications about the status of the process which
are visible above the GUI itself. Prevent this by providing a flag in
the status file which can disable these messages.

Integrate this flag to suppress messages when installing in full-screen
mode and reset it when a `clean` is called.

KanoComputing/peldins#1791
Also pauses all notifications until the updater has run its course so that
they are not lost but not shown during this time.

cc @pazdera 