### PR TITLE
Notifications: Rename flag for muting notifications

### DIFF
--- a/bin/kano-updater
+++ b/bin/kano-updater
@@ -66,7 +66,7 @@ def clean_up():
     remove_pid_file()
 
     status = UpdaterStatus.get_instance()
-    status.is_gui_running = False
+    status.notifications_muted = False
     status.save()
 
     notifications.resume()
@@ -77,7 +77,7 @@ def run_install(gui=False, confirm=True, splash_pid=None):
         notifications.pause()
 
         status = UpdaterStatus.get_instance()
-        status.is_gui_running = True
+        status.notifications_muted = True
         status.save()
 
         from kano_updater.ui.main import launch_install_gui

--- a/kano_updater/commands/clean.py
+++ b/kano_updater/commands/clean.py
@@ -32,7 +32,7 @@ def clean():
         msg = "The status was changed to: {}".format(status.state)
         logger.debug(msg)
 
-    status.is_gui_running = False
+    status.notifications_muted = False
 
     status.save()
 

--- a/kano_updater/status.py
+++ b/kano_updater/status.py
@@ -55,7 +55,7 @@ class UpdaterStatus(object):
         self._state = self.NO_UPDATES
         self._last_check = 0
         self._last_update = 0
-        self._is_gui_running = False
+        self._notifications_muted = False
 
         ensure_dir(os.path.dirname(self._status_file))
         if not os.path.exists(self._status_file):
@@ -82,15 +82,15 @@ class UpdaterStatus(object):
             self._last_update = data['last_update']
             self._last_check = data['last_check']
 
-            if 'is_gui_running' in data:
-                self._is_gui_running = (data['is_gui_running'] == 1)
+            if 'notifications_muted' in data:
+                self._notifications_muted = (data['notifications_muted'] == 1)
 
     def save(self):
         data = {
             'state': self._state,
             'last_update': self._last_update,
             'last_check': self._last_check,
-            'is_gui_running': 1 if self._is_gui_running else 0
+            'notifications_muted': 1 if self._notifications_muted else 0
         }
 
         with open(self._status_file, 'w') as status_file:
@@ -136,18 +136,18 @@ class UpdaterStatus(object):
         self._last_check = value
 
     """
-    # -- is_gui_running
+    # -- notifications_muted
 
     Stored internally as a boolean but saved to file as 0/1 to interface with C
     """
     @property
-    def is_gui_running(self):
-        return self._is_gui_running
+    def notifications_muted(self):
+        return self._notifications_muted
 
-    @is_gui_running.setter
-    def is_gui_running(self, value):
+    @notifications_muted.setter
+    def notifications_muted(self, value):
         if not isinstance(value, bool):
-            msg = "'is_gui_running' must be a boolean value."
+            msg = "'notifications_muted' must be a boolean value."
             raise UpdaterStatusError(msg)
 
-        self._is_gui_running = value
+        self._notifications_muted = value

--- a/lxpanel-plugin/kano_updater.c
+++ b/lxpanel-plugin/kano_updater.c
@@ -109,7 +109,7 @@ typedef struct {
     gchar *prev_state;
     int last_update;
     int last_check;
-    int is_gui_running;
+    int notifications_muted;
 
     GtkWidget *icon;
 
@@ -142,7 +142,7 @@ static GtkWidget *plugin_constructor(LXPanel *panel, config_setting_t *settings)
     plugin_data->prev_state = g_new0(gchar, MAX_STATE_LENGTH);
     plugin_data->last_update = 0;
     plugin_data->last_check = 0;
-    plugin_data->is_gui_running = FALSE;
+    plugin_data->notifications_muted = FALSE;
 
     GtkWidget *icon = gtk_image_new_from_file(NO_UPDATES_ICON_FILE);
     plugin_data->icon = icon;
@@ -321,8 +321,8 @@ static gboolean read_status(kano_updater_plugin_t *plugin_data)
             plugin_data->last_update = (int)
                 json_object_get_number(root, "last_update");
 
-            plugin_data->is_gui_running = (int)
-                json_object_get_number(root, "is_gui_running");
+            plugin_data->notifications_muted = (int)
+                json_object_get_number(root, "notifications_muted");
 
             json_value_free(root_value);
             return TRUE;
@@ -346,21 +346,21 @@ static gboolean update_status(kano_updater_plugin_t *plugin_data)
                           UPDATES_AVAILABLE_ICON_FILE);
 
         if (g_strcmp0(plugin_data->prev_state, plugin_data->state) != 0 &&
-            !plugin_data->is_gui_running)
+            !plugin_data->notifications_muted)
             show_notification(UPDATES_AVAILABLE_NOTIFICATION);
     } else if (IS_IN_STATE(plugin_data, "downloading-updates")) {
         gtk_image_set_from_file(GTK_IMAGE(plugin_data->icon),
                         DOWNLOADING_UPDATES_ICON_FILE);
 
         if (g_strcmp0(plugin_data->prev_state, plugin_data->state) != 0 &&
-            !plugin_data->is_gui_running)
+            !plugin_data->notifications_muted)
             show_notification(UPDATES_DOWNLOADING_NOTIFICATION);
     } else if (IS_IN_STATE(plugin_data, "updates-downloaded")) {
         gtk_image_set_from_file(GTK_IMAGE(plugin_data->icon),
                         UPDATES_DOWNLOADED_ICON_FILE);
 
         if (g_strcmp0(plugin_data->prev_state, plugin_data->state) != 0 &&
-            !plugin_data->is_gui_running)
+            !plugin_data->notifications_muted)
             show_notification(UPDATES_DOWNLOADED_NOTIFICATION);
     } else {
         gtk_image_set_from_file(GTK_IMAGE(plugin_data->icon),


### PR DESCRIPTION
The original flag was called `is_gui_running` but this can be confusing
and suppressing the notifications may be desired in situations other
than when the GUI is running so rename it to a more sensible name
(`notifications_muted`).

cc @pazdera 