### PR TITLE
Notifications: Don't show on boot if a dialog appears

### DIFF
--- a/kano_updater/commands/clean.py
+++ b/kano_updater/commands/clean.py
@@ -11,7 +11,7 @@ from kano_updater.status import UpdaterStatus
 # from kano_updater.ui.
 
 
-def clean():
+def clean(dry_run=False):
     status = UpdaterStatus.get_instance()
 
     old_status = status.state
@@ -34,6 +34,7 @@ def clean():
 
     status.notifications_muted = False
 
-    status.save()
+    if not dry_run:
+        status.save()
 
     return old_status

--- a/kano_updater/ui/main.py
+++ b/kano_updater/ui/main.py
@@ -72,7 +72,9 @@ def launch_check_gui():
 def launch_boot_gui():
     # FIXME: This window uses Gtk2 which requires the other Gtk imports to be
     #        loaded in the scope of the functions that require them.
-    old_status = clean()
+    old_status = clean(dry_run=True)
+    status = UpdaterStatus.get_instance()
+
     if old_status == UpdaterStatus.INSTALLING_UPDATES:
         from kano.gtk3.kano_dialog import KanoDialog
         d = KanoDialog(
@@ -86,7 +88,7 @@ def launch_boot_gui():
         del d
 
         if rv:
-            status = UpdaterStatus.get_instance()
+            status.notifications_muted = True
             status.state = UpdaterStatus.NO_UPDATES
             status.save()
 
@@ -107,6 +109,8 @@ def launch_boot_gui():
         from kano_updater.ui.changes_dialog import ChangesDialog
         win = ChangesDialog()
         win.run()
+
+    status.save()
 
 
 def launch_relaunch_countdown_gui(parent_pid):


### PR DESCRIPTION
KanoComputing/peldins#1915
When booting, if the updater had to reboot to be able to continue, a
message is shown to prompt the user to carry on with the update. This
accompanies a status change which triggers a notification. If this is
the case, disable the notification so that two calls to action aren't
present.

cc @pazdera 