### PR TITLE
Notification: Remove status file check on init

### DIFF
--- a/lxpanel-plugin/kano_updater.c
+++ b/lxpanel-plugin/kano_updater.c
@@ -172,8 +172,6 @@ static GtkWidget *plugin_constructor(LXPanel *panel, config_setting_t *settings)
 
     gtk_widget_set_sensitive(icon, TRUE);
 
-    update_status(plugin_data);
-
     plugin_data->timer = g_timeout_add(POLL_INTERVAL,
                        (GSourceFunc) check_for_updates,
                        (gpointer) plugin_data);


### PR DESCRIPTION
KanoComputing/peldins#1923
When the notification widget is initialised, the status file is checked
and, if appropriate, a notification may be triggered. This causes
unknown lock-ups when a user attempts to click the buttons on the
notification.

Instead, remove this call in the constructor and rely on the status file
monitor to trigger the notifications. The Updater boot check modifies
the file anyway so the notification is triggered but without the
lock-up.

cc @pazdera @Ealdwulf @skarbat @convolu 