### PR TITLE
Fix no-install

### DIFF
--- a/kano_updater/commands/download.py
+++ b/kano_updater/commands/download.py
@@ -13,7 +13,7 @@ from kano_updater.paths import PIP_PACKAGES_LIST
 from kano_updater.status import UpdaterStatus
 from kano_updater.apt_wrapper import apt_handle
 from kano_updater.progress import DummyProgress, Phase
-from kano_updater.utils import run_pip_command, is_server_available
+from kano_updater.utils import run_pip_command, is_server_available, ensure_dir
 from kano_updater.commands.check import check_for_updates
 
 
@@ -139,6 +139,10 @@ def _cache_pip_packages(progress):
     phase_name = 'downloading-pip-pkgs'
     progress.start(phase_name)
 
+    pip_cache = '/var/cache/kano-updater/pkg_cache'
+
+    ensure_dir(pip_cache)
+
     packages = read_file_contents_as_lines(PIP_PACKAGES_LIST)
     progress.init_steps(phase_name, len(packages))
 
@@ -148,7 +152,7 @@ def _cache_pip_packages(progress):
         # The `--no-install` parameter has been deprecated in pip. However, the
         # version of pip in wheezy doesn't yet support the new approach which
         # is supposed to provide the same behaviour.
-        args = "install --upgrade --no-install '{}'".format(pkg)
+        args = "install --upgrade --download '{}' '{}'".format(pip_cache, pkg)
         success = run_pip_command(args)
 
         # TODO: abort the install?

--- a/kano_updater/commands/download.py
+++ b/kano_updater/commands/download.py
@@ -9,7 +9,7 @@ from kano.network import is_internet
 from kano.logging import logger
 from kano.utils import read_file_contents_as_lines, ensure_dir
 
-from kano_updater.paths import PIP_PACKAGES_LIST
+from kano_updater.paths import PIP_PACKAGES_LIST, PIP_CACHE_DIR
 from kano_updater.status import UpdaterStatus
 from kano_updater.apt_wrapper import apt_handle
 from kano_updater.progress import DummyProgress, Phase
@@ -139,9 +139,7 @@ def _cache_pip_packages(progress):
     phase_name = 'downloading-pip-pkgs'
     progress.start(phase_name)
 
-    pip_cache = '/var/cache/kano-updater/pkg_cache'
-
-    ensure_dir(pip_cache)
+    ensure_dir(PIP_CACHE_DIR)
 
     packages = read_file_contents_as_lines(PIP_PACKAGES_LIST)
     progress.init_steps(phase_name, len(packages))
@@ -152,7 +150,8 @@ def _cache_pip_packages(progress):
         # The `--no-install` parameter has been deprecated in pip. However, the
         # version of pip in wheezy doesn't yet support the new approach which
         # is supposed to provide the same behaviour.
-        args = "install --upgrade --download '{}' '{}'".format(pip_cache, pkg)
+        args = "install --upgrade --download '{}' '{}'".format(PIP_CACHE_DIR,
+                                                               pkg)
         success = run_pip_command(args)
 
         # TODO: abort the install?

--- a/kano_updater/commands/download.py
+++ b/kano_updater/commands/download.py
@@ -7,13 +7,13 @@
 
 from kano.network import is_internet
 from kano.logging import logger
-from kano.utils import read_file_contents_as_lines
+from kano.utils import read_file_contents_as_lines, ensure_dir
 
 from kano_updater.paths import PIP_PACKAGES_LIST
 from kano_updater.status import UpdaterStatus
 from kano_updater.apt_wrapper import apt_handle
 from kano_updater.progress import DummyProgress, Phase
-from kano_updater.utils import run_pip_command, is_server_available, ensure_dir
+from kano_updater.utils import run_pip_command, is_server_available
 from kano_updater.commands.check import check_for_updates
 
 

--- a/kano_updater/commands/install.py
+++ b/kano_updater/commands/install.py
@@ -12,7 +12,8 @@ from kano.logging import logger
 from kano.utils import read_file_contents_as_lines, get_free_space, run_cmd
 from kano.network import is_internet
 
-from kano_updater.paths import PIP_PACKAGES_LIST, SYSTEM_VERSION_FILE
+from kano_updater.paths import PIP_PACKAGES_LIST, SYSTEM_VERSION_FILE, \
+    PIP_CACHE_DIR
 from kano_updater.status import UpdaterStatus
 from kano_updater.os_version import OSVersion, bump_system_version, \
     TARGET_VERSION
@@ -247,8 +248,6 @@ def install_deb_packages(progress):
 def install_pip_packages(progress):
     phase_name = progress.get_current_phase().name
 
-    pip_cache = '/var/cache/kano-updater/pkg_cache'
-
     packages = read_file_contents_as_lines(PIP_PACKAGES_LIST)
     progress.init_steps(phase_name, len(packages))
 
@@ -257,7 +256,7 @@ def install_pip_packages(progress):
 
         success = run_pip_command(
             "install --upgrade --no-index --find-links=file://{} '{}'".format(
-                pip_cache, pkg)
+                PIP_CACHE_DIR, pkg)
         )
 
         if not success:

--- a/kano_updater/commands/install.py
+++ b/kano_updater/commands/install.py
@@ -267,3 +267,12 @@ def install_pip_packages(progress):
                 msg = "Network is down, aborting PIP install"
                 logger.error(msg)
                 raise IOError(msg)
+
+            # Try with the failsafe method
+            success_failsafe = run_pip_command(
+                "install --upgrade '{}'".format(pkg)
+            )
+            if not success_failsafe:
+                msg = "Installing the '{}' pip package failed (fsafe)".format(
+                    pkg)
+                logger.error(msg)

--- a/kano_updater/commands/install.py
+++ b/kano_updater/commands/install.py
@@ -44,7 +44,7 @@ def install(progress=None):
         logger.warn(err_msg)
         answer = progress.prompt(
             'Feeling full!',
-            'My brain is feeling a bit full, but I can make some more ' \
+            'My brain is feeling a bit full, but I can make some more '
             'room if you\'d like?',
             ['OK', 'CANCEL']
         )

--- a/kano_updater/commands/install.py
+++ b/kano_updater/commands/install.py
@@ -247,13 +247,18 @@ def install_deb_packages(progress):
 def install_pip_packages(progress):
     phase_name = progress.get_current_phase().name
 
+    pip_cache = '/var/cache/kano-updater/pkg_cache'
+
     packages = read_file_contents_as_lines(PIP_PACKAGES_LIST)
     progress.init_steps(phase_name, len(packages))
 
     for pkg in packages:
         progress.next_step(phase_name, "Installing {}".format(pkg))
 
-        success = run_pip_command("install --upgrade '{}'".format(pkg))
+        success = run_pip_command(
+            "install --upgrade --no-index --find-links=file://{} '{}'".format(
+                pip_cache, pkg)
+        )
 
         if not success:
             msg = "Installing the '{}' pip package failed".format(pkg)

--- a/kano_updater/paths.py
+++ b/kano_updater/paths.py
@@ -8,6 +8,7 @@
 
 PIP_PACKAGES_LIST = '/usr/share/kano-updater/python_modules'
 PIP_LOG_FILE = '/var/log/kano-updater-pip.log'
+PIP_CACHE_DIR = '/var/cache/kano-updater/pkg_cache'
 
 SYSTEM_ISSUE_FILE = '/etc/issue'
 SYSTEM_VERSION_FILE = '/etc/kanux_version'


### PR DESCRIPTION
With these changes we replace the use of the deprecated `--no-install` while downloading
the packages.

As the pip documentation now suggests we should create and maintain our own cache.
This also changes the way we install packages as we need to look in the newly created cache.

A failsafe method has been added that ensures that the packages are installed even if they are
not present in the cache 