### PR TITLE
Use the format X.Y.Z-B for the package version no

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-kano-updater (2.2-1) unstable; urgency=low
+kano-updater (2.2.0-1) unstable; urgency=low
 
   * Add support for security hotfixes
   * Add support for scheduling updates for later


### PR DESCRIPTION
The X.Y format of the version may cause issues and goes against the assumptions about urgent updates. This rectifies this