### PR TITLE
Fixes updates to latest Kano OS 2.2.0

### DIFF
--- a/kano_updater/scenarios.py
+++ b/kano_updater/scenarios.py
@@ -327,8 +327,8 @@ class PostUpdate(Scenarios):
         remove_user_files(['.kdesktop/YouTube.lnk'])
 
     def beta_201_to_beta_210(self):
-        from kano_settings.system.advanced import set_everyone_youtube_cookies
-        set_everyone_youtube_cookies()
+        from kano_settings.system.advanced import set_everyone_cookies
+        set_everyone_cookies()
 
     def beta_210_to_beta_220(self):
         install('telnet python-serial')

--- a/kano_updater/scenarios.py
+++ b/kano_updater/scenarios.py
@@ -130,7 +130,7 @@ class PreUpdate(Scenarios):
                           self.beta_201_to_beta_210)
 
         self.add_scenario("Kanux-Beta-2.1.0", "Kanux-Beta-2.2.0",
-                          self.beta_210_to_beta_210)
+                          self.beta_210_to_beta_220)
 
     def beta_103_to_beta_110(self):
         pass
@@ -248,7 +248,7 @@ class PostUpdate(Scenarios):
         self.add_scenario("Kanux-Beta-2.0.1", "Kanux-Beta-2.1.0",
                           self.beta_201_to_beta_210)
 
-        self.add_scenario("Kanux-Beta-2.1.0", "Kanux-Beta-2.1.1",
+        self.add_scenario("Kanux-Beta-2.1.0", "Kanux-Beta-2.2.0",
                           self.beta_210_to_beta_220)
 
     def beta_103_to_beta_110(self):


### PR DESCRIPTION
This fixes broken updates currently in production to Kano OS 2.2.0 in the scenarios.

@tombettany @pazdera @convolu Could you please review this?