### PR TITLE
First boot countdown

### DIFF
--- a/bin/kano-updater
+++ b/bin/kano-updater
@@ -199,8 +199,13 @@ def main():
         # spoof the last_check timestamp to four days ago so the user won't
         # be prompted to update in the first three days after boot
         status = UpdaterStatus.get_instance()
+        # stop update notifications for three days
+        three_days = 3 * 24 * 60 * 60
+        status.first_boot_countdown = int(time.time() + three_days)
+        # set the last check flag four days ago to only check for updates in 3 days again
         four_days_ago = int(time.time() - 4 * 24 * 60 * 60)
         status.last_check = status.last_update = four_days_ago
+        # set the urgent last check flag to yesterday to immediately check again
         one_day_ago = int(time.time() - 24 * 60 * 60)
         status.last_check_urgent = one_day_ago
         status.save()
@@ -252,7 +257,8 @@ def main():
             #    updates_available = launch_check_gui()
             # else:
             updates_available = check_for_updates(progress=progress,
-                                                  priority=priority)
+                                                  priority=priority,
+                                                  is_gui=args['gui'])
 
             if updates_available:
                 status = UpdaterStatus.get_instance()

--- a/bin/kano-updater
+++ b/bin/kano-updater
@@ -258,7 +258,7 @@ def main():
             # else:
             updates_available = check_for_updates(progress=progress,
                                                   priority=priority,
-                                                  is_gui=args['gui'])
+                                                  is_gui=args['--gui'])
 
             if updates_available:
                 status = UpdaterStatus.get_instance()

--- a/kano_updater/commands/check.py
+++ b/kano_updater/commands/check.py
@@ -19,7 +19,7 @@ import kano_updater.priority as Priority
 KANO_SOURCES_LIST = '/etc/apt/sources.list.d/kano.list'
 
 
-def check_for_updates(progress=None, priority=Priority.NONE):
+def check_for_updates(progress=None, priority=Priority.NONE, is_gui=False):
     status = UpdaterStatus.get_instance()
 
     # FIXME: FOR DEBUGGING ONLY
@@ -30,6 +30,15 @@ def check_for_updates(progress=None, priority=Priority.NONE):
 
     if not progress:
         progress = DummyProgress()
+
+    countdown = status.first_boot_countdown - int(time.time())
+
+    # block update checks when:
+    #  1) three days have NOT passed since the first boot
+    #  2) and not checking for URGENT updates
+    #  3) and the check is triggered from background hooks (not by user)
+    if (countdown > 0) and (priority is not Priority.URGENT) and (not is_gui):
+        return False
 
     if status.state != UpdaterStatus.NO_UPDATES:
         msg = _('No need to check for updates')

--- a/kano_updater/status.py
+++ b/kano_updater/status.py
@@ -56,6 +56,7 @@ class UpdaterStatus(object):
         self._last_check = 0
         self._last_check_urgent = 0
         self._last_update = 0
+        self._first_boot_countdown = 0
         self._is_urgent = False
         self._is_scheduled = False
         self._notifications_muted = False
@@ -77,6 +78,7 @@ class UpdaterStatus(object):
                 data['last_update']
                 data['last_check']
                 data['last_check_urgent']
+                data['first_boot_countdown']
                 data['is_urgent']
                 data['is_scheduled']
                 data['is_shutdown']
@@ -90,6 +92,7 @@ class UpdaterStatus(object):
             self._last_update = data['last_update']
             self._last_check = data['last_check']
             self._last_check_urgent = data['last_check_urgent']
+            self._first_boot_countdown = data['first_boot_countdown']
             self._is_urgent = (data['is_urgent'] == 1)
             self._is_scheduled = (data['is_scheduled'] == 1)
             self._is_shutdown = (data['is_shutdown'] == 1)
@@ -103,6 +106,7 @@ class UpdaterStatus(object):
             'last_update': self._last_update,
             'last_check': self._last_check,
             'last_check_urgent': self._last_check_urgent,
+            'first_boot_countdown': self._first_boot_countdown,
             'is_urgent': 1 if self._is_urgent else 0,
             'is_scheduled': 1 if self._is_scheduled else 0,
             'is_shutdown': 1 if self._is_shutdown else 0,
@@ -189,6 +193,19 @@ class UpdaterStatus(object):
             raise UpdaterStatusError(msg)
 
         self._last_check_urgent = value
+
+    # -- first_boot_countdown - used to stop updates for a set amount of time
+    @property
+    def first_boot_countdown(self):
+        return self._first_boot_countdown
+
+    @first_boot_countdown.setter
+    def first_boot_countdown(self, value):
+        if not isinstance(value, int):
+            msg = "'first_boot_countdown' must be an Unix timestamp (int)."
+            raise UpdaterStatusError(msg)
+
+        self._first_boot_countdown = value
 
     """
     # -- notifications_muted


### PR DESCRIPTION
Added the capability of setting a time slot after the first ever boot in which update
notifications are supressed. The time slot is currently three days.

WARNING: This is still susceptible to date/time changes after the first boot!

@alex5imon @tombettany @pazdera could you please review this?