### PR TITLE
Added tracking to Flappy Judoka

### DIFF
--- a/kano_updater/ui/media/flappy-judoka/bin/flappy-judoka
+++ b/kano_updater/ui/media/flappy-judoka/bin/flappy-judoka
@@ -44,11 +44,19 @@ if __name__ == '__main__' and __package__ is None:
 from src.core.gameloop import Gameloop
 from src.utils import debugger, is_running
 
+from kano_profile.tracker import track_action, session_start, session_end
+
+
+# how long the game is being played for
+tracking_session = None
+
 
 # UNCOMMENT THE 2 LINES BELOW TO GET A PROFILE FOR THE GAME
 # from profilehooks import profile
 # @profile
 def main():
+    global tracking_session
+
     # make sure the game launches only once
     if is_running():
         debugger('flappy-judoka: main: Game is already running! Exiting..')
@@ -68,6 +76,13 @@ def main():
     except:
         debugger('ERROR: flappy-judoka: main: Loading docopt parameters failed!')
 
+    # tracking for how long the game is running
+    try:
+        track_action('updater-flappy-judoka-start')
+        tracking_session = session_start('updater-flappy-judoka', os.getpid())
+    except Exception:
+        debugger('ERROR: flappy-judoka: main: Starting tracking session failed!')
+
     pygame.init()
     debugger('flappy-judoka: main: Started')
 
@@ -75,6 +90,12 @@ def main():
 
     debugger('flappy-judoka: main: Exiting')
     pygame.quit()
+
+    # letting the tracking session know the game is closing
+    try:
+        session_end(tracking_session)
+    except:
+        debugger('ERROR: flappy-judoka: main: Ending tracking session failed!')
 
 
 if __name__ == '__main__':

--- a/kano_updater/ui/media/flappy-judoka/bin/flappy-judoka
+++ b/kano_updater/ui/media/flappy-judoka/bin/flappy-judoka
@@ -45,6 +45,7 @@ from src.core.gameloop import Gameloop
 from src.utils import debugger, is_running
 
 from kano_profile.tracker import track_action, session_start, session_end
+from kano.logging import logger
 
 
 # how long the game is being played for
@@ -81,6 +82,7 @@ def main():
         track_action('updater-flappy-judoka-start')
         tracking_session = session_start('updater-flappy-judoka', os.getpid())
     except Exception:
+        logger.warn('Starting tracking session failed!')
         debugger('ERROR: flappy-judoka: main: Starting tracking session failed!')
 
     pygame.init()
@@ -95,6 +97,7 @@ def main():
     try:
         session_end(tracking_session)
     except:
+        logger.warn('Ending tracking session failed!')
         debugger('ERROR: flappy-judoka: main: Ending tracking session failed!')
 
 

--- a/kano_updater/ui/media/flappy-judoka/src/core/gamestate.py
+++ b/kano_updater/ui/media/flappy-judoka/src/core/gamestate.py
@@ -23,6 +23,8 @@ from src.actors.ground import GroundManager
 from src.graphics.collision import check_collision
 from src.utils import debugger
 
+from kano_profile.tracker import track_data
+
 
 class Gamestate(object):
     '''
@@ -382,6 +384,14 @@ class GameOverState(GamestateTemplate):
         self.score = score
 
         self.pipes.reset_pipes()
+
+        try:
+            # TODO: track best score as well
+            track_data('updater-flappy-judoka', {
+                'score': score
+            })
+        except:
+            debugger('ERROR: GameOverState: __init__: Tracking the users score failed!')
 
     # @Override
     def state_controls(self, event):

--- a/kano_updater/ui/media/flappy-judoka/src/core/gamestate.py
+++ b/kano_updater/ui/media/flappy-judoka/src/core/gamestate.py
@@ -24,6 +24,7 @@ from src.graphics.collision import check_collision
 from src.utils import debugger
 
 from kano_profile.tracker import track_data
+from kano.logging import logger
 
 
 class Gamestate(object):
@@ -387,10 +388,11 @@ class GameOverState(GamestateTemplate):
 
         try:
             # TODO: track best score as well
-            track_data('updater-flappy-judoka', {
+            track_data('updater-flappy-judoka-score', {
                 'score': score
             })
         except:
+            logger.warn('Tracking the users score failed!')
             debugger('ERROR: GameOverState: __init__: Tracking the users score failed!')
 
     # @Override


### PR DESCRIPTION
Tracking events added:
  - session length: how long the game is being run for
  - action: when the game is being launched
  - data: player score when flappy dies

@alex5imon @pazdera could you please review this?