### PR TITLE
Relaunch: Fix passing splash PID between instances

### DIFF
--- a/kano_updater/ui/main.py
+++ b/kano_updater/ui/main.py
@@ -20,15 +20,15 @@ from kano_updater.status import UpdaterStatus
 from kano_updater.utils import show_relaunch_splash, remove_pid_file
 
 relaunch_required_flag = False
-splash_pid = None
+launched_splash_pid = None
 
 
 def relaunch_required():
     global relaunch_required_flag
-    global splash_pid
+    global launched_splash_pid
 
     relaunch_required_flag = True
-    splash_pid = show_relaunch_splash()
+    launched_splash_pid = show_relaunch_splash()
 
 
 def launch_install_gui(confirm=False, splash_pid=None):
@@ -51,7 +51,7 @@ def launch_install_gui(confirm=False, splash_pid=None):
 
     if relaunch_required_flag:
         r_exc = Relaunch()
-        r_exc.pid = splash_pid
+        r_exc.pid = launched_splash_pid
         raise r_exc
 
 


### PR DESCRIPTION
When relaunching the updater, a relaunch splash screen is created to
mask the underlying updater restart. This relies on passing the splash
screen PID between updater instances so that the latter version can kill
the splash screen.

The handling of both passing the PID of the splash screen to the
`exec()` call for relaunch and killing the splash screen after relaunch
were within the same function so some variables were used twice (to mean
both the PID of the launched splash and the currently running splash
PID) which lead to undetermined behaviour. Fix this by separating the
two uses.

@pazdera @radujipa could you review?