### PR TITLE
Relaunching Lxpanel in the cleanup if FlappyJudoka was launched

### DIFF
--- a/bin/kano-updater
+++ b/bin/kano-updater
@@ -24,9 +24,10 @@ Options:
   -h, --help       Show this message.
   -v, --version    Print the version of the updater.
   -g, --gui        Run the install procedure with a GUI.
-  --no-confirm     Don't confirm before installing
   -l, --low-prio   Run the process with low shed and io priority.
   --interval       Minimum time interval between checks (in hours)
+  --no-confirm     Don't confirm before installing
+  --urgent         Check for urgent updates
 """
 
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,12 @@
+kano-updater (2.4.0-1) unstable; urgency=low
+
+  * Improved Flappy Judoka game launching
+
+ -- Team Kano <dev@kano.me>  Wed, 20 Jan 2016 14:35:00 +0000
+
 kano-updater (2.3.0-1) unstable; urgency=low
 
   * Install Make Light by default
-  * Improved Flappy Judoka game launching
 
  -- Team Kano <dev@kano.me>  Wed, 20 Jan 2016 14:35:00 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 kano-updater (2.3.0-1) unstable; urgency=low
 
   * Install Make Light by default
+  * Improved Flappy Judoka game launching
 
  -- Team Kano <dev@kano.me>  Wed, 20 Jan 2016 14:35:00 +0000
 

--- a/kano_updater/ui/install_window.py
+++ b/kano_updater/ui/install_window.py
@@ -1,11 +1,10 @@
-
 # install_window.py
 #
-# Copyright (C) 2015 Kano Computing Ltd.
+# Copyright (C) 2015-2016 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 #
 # Installer main window
-#
+
 
 import os
 from gi.repository import Gtk, Gdk, GLib
@@ -14,7 +13,7 @@ from threading import Thread, Lock
 from kano.gtk3.apply_styles import apply_styling_to_screen
 from kano.gtk3.kano_dialog import KanoDialog
 
-from kano_updater.utils import kill_apps
+from kano_updater.utils import kill_apps, kill_flappy_judoka
 from kano_updater.ui.paths import CSS_PATH
 from kano_updater.commands.install import install
 from kano_updater.ui.progress import GtkProgress
@@ -79,6 +78,7 @@ class InstallWindow(Gtk.Window):
         self.destroy()
         self._set_normal_cursor()
 
+        kill_flappy_judoka()
         unexpected_quit = KanoDialog(
             _('The install quit unexpectedly'),
             _('Please try again later'),
@@ -110,6 +110,7 @@ class InstallWindow(Gtk.Window):
         self.destroy()
         self._set_normal_cursor()
 
+        kill_flappy_judoka()
         no_updates = KanoDialog(
             _('No updates available'),
             _('Your system is already up to date'),
@@ -160,6 +161,7 @@ class InstallWindow(Gtk.Window):
         return False
 
     def error(self, msg):
+        kill_flappy_judoka()
         error = KanoDialog(
             _('Error updating'), msg,
             {

--- a/kano_updater/ui/install_window.py
+++ b/kano_updater/ui/install_window.py
@@ -13,7 +13,7 @@ from threading import Thread, Lock
 from kano.gtk3.apply_styles import apply_styling_to_screen
 from kano.gtk3.kano_dialog import KanoDialog
 
-from kano_updater.utils import kill_apps, kill_flappy_judoka
+from kano_updater.utils import kill_apps, kill_flappy_judoka, bring_flappy_judoka_to_front
 from kano_updater.ui.paths import CSS_PATH
 from kano_updater.commands.install import install
 from kano_updater.ui.progress import GtkProgress
@@ -30,13 +30,7 @@ class InstallWindow(Gtk.Window):
         apply_styling_to_screen(self.CSS_FILE)
 
         Gtk.Window.__init__(self)
-        # self.fullscreen()
-        # Gtk hack: set the width, height of the window to larger than screen
-        # resolution in order fix set_keep_below(True) which doesn't work with fullscreen
-        screen = Gdk.Screen.get_default()
-        width = screen.get_width()
-        height = screen.get_height()
-        self.set_size_request(width, height + 80)
+        self.fullscreen()
         self.set_keep_above(True)
 
         self.set_icon_name('kano-updater')
@@ -59,6 +53,7 @@ class InstallWindow(Gtk.Window):
         self.user_input_lock.acquire()
 
         self._start_install()
+        bring_flappy_judoka_to_front()
 
     def _start_install(self):
         progress = GtkProgress(self)

--- a/kano_updater/ui/media/flappy-judoka/src/graphics/display.py
+++ b/kano_updater/ui/media/flappy-judoka/src/graphics/display.py
@@ -1,7 +1,7 @@
 
 # display.py
 #
-# Copyright (C) 2015 Kano Computing Ltd.
+# Copyright (C) 2015-2016 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 #
 #
@@ -14,7 +14,7 @@ import pygame
 from src.core.gamestate import Gamestate
 from src.graphics.hud import IntroHUD, NewGameHUD, FlappyFlyingHUD, GameOverHUD
 from src.graphics.assets import Assets
-from src.utils import debugger
+from src.utils import debugger, set_window_on_top
 
 
 class Display(object):
@@ -79,6 +79,7 @@ class Display(object):
         It provides the implementation of the state change listener
         such that the Display can react on specific state transitions.
         '''
+        set_window_on_top(self.GAME_TITLE)
         Gamestate.get().add_gamestate_change_listener(self.mGamestateChangeListener(self))
 
     def randomise_background(self):

--- a/kano_updater/ui/media/flappy-judoka/src/graphics/display.py
+++ b/kano_updater/ui/media/flappy-judoka/src/graphics/display.py
@@ -14,7 +14,7 @@ import pygame
 from src.core.gamestate import Gamestate
 from src.graphics.hud import IntroHUD, NewGameHUD, FlappyFlyingHUD, GameOverHUD
 from src.graphics.assets import Assets
-from src.utils import debugger, set_window_on_top
+from src.utils import debugger, set_window_on_top, setup_window_on_top_signal
 
 
 class Display(object):
@@ -79,7 +79,8 @@ class Display(object):
         It provides the implementation of the state change listener
         such that the Display can react on specific state transitions.
         '''
-        set_window_on_top(self.GAME_TITLE)
+        setup_window_on_top_signal()
+        set_window_on_top()
         Gamestate.get().add_gamestate_change_listener(self.mGamestateChangeListener(self))
 
     def randomise_background(self):

--- a/kano_updater/ui/media/flappy-judoka/src/utils.py
+++ b/kano_updater/ui/media/flappy-judoka/src/utils.py
@@ -1,7 +1,7 @@
 
 # utils.py
 #
-# Copyright (C) 2015 Kano Computing Ltd.
+# Copyright (C) 2015-2016 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 #
 #
@@ -110,12 +110,11 @@ def rotate_center(image, rect, angle):
     return rot_image, rot_rect
 
 
-def set_window_on_top(display):
+def set_window_on_top(window_name):
     '''
     NOTE: This function is designed to work for the RPI!
     '''
     try:
-        os.system('wmctrl -a -r "{}" -b add,above &'.format(display.GAME_TITLE))
+        os.system('wmctrl -r "{}" -b add,above &'.format(window_name))
     except:
         debugger('ERROR: utils: set_window_on_top: wmctrl failed!')
-    display.is_set_to_top = True

--- a/kano_updater/ui/media/flappy-judoka/src/utils.py
+++ b/kano_updater/ui/media/flappy-judoka/src/utils.py
@@ -10,6 +10,7 @@
 
 import os
 import sys
+import signal
 import pygame
 
 from paths import images_path, sounds_path
@@ -110,11 +111,25 @@ def rotate_center(image, rect, angle):
     return rot_image, rot_rect
 
 
-def set_window_on_top(window_name):
+def setup_window_on_top_signal():
+    signal.signal(signal.SIGUSR1, give_focus_to_game)
+
+
+def give_focus_to_game(signal=None, frame=None):
     '''
     NOTE: This function is designed to work for the RPI!
     '''
     try:
-        os.system('wmctrl -r "{}" -b add,above &'.format(window_name))
+        os.system('wmctrl -a "Flappy Judoka" &')
+    except:
+        debugger('ERROR: utils: give_focus_to_game: wmctrl failed!')
+
+
+def set_window_on_top(signal=None, frame=None):
+    '''
+    NOTE: This function is designed to work for the RPI!
+    '''
+    try:
+        os.system('wmctrl -r "Flappy Judoka" -b add,above &')
     except:
         debugger('ERROR: utils: set_window_on_top: wmctrl failed!')

--- a/kano_updater/ui/progress.py
+++ b/kano_updater/ui/progress.py
@@ -24,7 +24,6 @@ class GtkProgress(Progress):
                       phase.get_main_phase().label, phase.get_main_phase().name, msg)
 
     def _error(self, phase, msg):
-        kill_flappy_judoka()
         err_msg = "Error {} - {}".format(phase.label.lower(), msg)
         GLib.idle_add(self._window.error, err_msg)
 

--- a/kano_updater/ui/progress.py
+++ b/kano_updater/ui/progress.py
@@ -1,16 +1,16 @@
-
 # progress.py
 #
-# Copyright (C) 2015 Kano Computing Ltd.
+# Copyright (C) 2015-2016 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 #
 # Thread-safe progress reporting for Gtk
-#
+
 
 from gi.repository import GLib, Gtk
 
 from kano_updater.progress import Progress
 from kano_updater.ui.main import relaunch_required
+from kano_updater.utils import kill_flappy_judoka
 
 
 class GtkProgress(Progress):
@@ -24,10 +24,12 @@ class GtkProgress(Progress):
                       phase.get_main_phase().label, phase.get_main_phase().name, msg)
 
     def _error(self, phase, msg):
+        kill_flappy_judoka()
         err_msg = "Error {} - {}".format(phase.label.lower(), msg)
         GLib.idle_add(self._window.error, err_msg)
 
     def _abort(self, phase, msg):
+        kill_flappy_judoka()
         err_msg = "{} - {}".format(phase.label.lower(), msg)
         GLib.idle_add(self._window.error, err_msg)
 

--- a/kano_updater/ui/relaunch_window.py
+++ b/kano_updater/ui/relaunch_window.py
@@ -14,6 +14,8 @@ from kano.gtk3.apply_styles import apply_styling_to_screen
 
 from kano_updater.ui.paths import CSS_PATH
 from kano_updater.ui.views.relaunch import Relaunch
+from kano_updater.utils import bring_flappy_judoka_to_front
+
 
 class RelaunchWindow(Gtk.Window):
     CSS_FILE = os.path.join(CSS_PATH, 'updater.css')
@@ -34,6 +36,8 @@ class RelaunchWindow(Gtk.Window):
 
         self.show_all()
         self._set_wait_cursor()
+
+        bring_flappy_judoka_to_front()
 
     def _set_wait_cursor(self):
         cursor = Gdk.Cursor.new(Gdk.CursorType.WATCH)

--- a/kano_updater/ui/views/install.py
+++ b/kano_updater/ui/views/install.py
@@ -115,8 +115,6 @@ class Install(Gtk.Overlay):
     def update_progress(self, percent, phase_name, msg, sub_msg=''):
         # enabling flappy-judoka launch only after these phases (when a reboot is iminent)
         if phase_name in ['downloading', 'downloading-pip-pkgs', 'init', 'installing-urgent']:
-            # killing the notification daemon in case there are frozen notifications at this point
-            os.system('pkill -f kano-notifications-daemon')
             if has_min_performance(RPI_2_B_SCORE):
                 self.get_toplevel().connect('key-release-event', self._launch_game)
                 self._pgl.show()

--- a/kano_updater/ui/views/install.py
+++ b/kano_updater/ui/views/install.py
@@ -1,19 +1,21 @@
-
 # install.py
 #
-# Copyright (C) 2015 Kano Computing Ltd.
+# Copyright (C) 2015-2016 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 #
 # Install widget
-#
 
 
 import os
+import traceback
 
 from gi.repository import Gtk, Gdk
+
 from kano_updater.ui.stage_text import STAGE_TEXT
 from kano_updater.ui.paths import FLAPPY_PATH
+
 from kano.utils import has_min_performance, RPI_2_B_SCORE
+from kano.logging import logger
 
 
 class Install(Gtk.Overlay):
@@ -21,7 +23,7 @@ class Install(Gtk.Overlay):
     def __init__(self):
         Gtk.Overlay.__init__(self, hexpand=True, vexpand=True)
 
-        style = self.get_style_context().add_class('install')
+        self.get_style_context().add_class('install')
 
         self._pgl = self._create_play_game_label()
         progress = self._create_progress_grid()
@@ -141,25 +143,8 @@ class Install(Gtk.Overlay):
     def _launch_game(self, window=None, event=None):
         try:
             if event and event.get_keyval()[1] in [Gdk.KEY_j, Gdk.KEY_J]:
-                if self._is_game_first_launch:
-                    self._is_game_first_launch = False
-                    self._first_game_launch(window)
-                else:
-                    self._relaunch_game()
+                os.system('{} &'.format(FLAPPY_PATH))
+
         except:
-            pass
-
-    def _first_game_launch(self, window=None):
-        # this function lets flappy-judoka run on top of the updater
-        if window is not None:
-            window.set_keep_below(True)
-
-        os.system('{} &'.format(FLAPPY_PATH))
-        os.system('pkill -KILL -f kano-feedback')      # kill kano-feedback-widget
-        os.system('pkill -KILL -f kano-world-widget')  # kill kano-world share widget
-        os.system('lxpanelctl exit')                   # kill lxpanel
-        # minimise all windows, and restore focus to the Updater and then Flappy
-        os.system('wmctrl -k on && wmctrl -a "Updater" && wmctrl -a "Flappy Judoka"')
-
-    def _relaunch_game(self):
-        os.system('{} &'.format(FLAPPY_PATH))
+            logger.error('Unexpected error in _launch_game()\n{}'
+                         .format(traceback.format_exc))

--- a/kano_updater/utils.py
+++ b/kano_updater/utils.py
@@ -14,12 +14,10 @@ import shutil
 import pwd
 import grp
 import signal
-import traceback
 
 from kano.logging import logger
 from kano.utils import run_print_output_error, run_cmd, run_bg, run_cmd_log, \
     chown_path, is_gui, sed, get_user_unsudoed
-from kano.utils import is_running as is_running_toolset
 from kano.network import is_internet
 import kano.notifications as notifications
 from kano.timeout import timeout, TimeoutError
@@ -133,9 +131,22 @@ def kill_flappy_judoka():
     """
     try:
         os.system('pkill -KILL -f flappy-judoka')
-    except Exception:
-        logger.error('Unexpected error in kill_flappy_judoka()\n{}'
-                     .format(traceback.format_exc))
+    except Exception as e:
+        logger.error('Unexpected error in kill_flappy_judoka()', exception=e)
+
+
+def bring_flappy_judoka_to_front():
+    """
+    Puts Flappy Judoka game on top of the updater.
+
+    It works by asking the window manager to give focus back to the game when
+    something else grabs it, i.e. when relaunching. This will happen in the
+    game's signal for SIGUSR1.
+    """
+    try:
+        os.system('pkill -USR1 -f flappy-judoka')
+    except Exception as e:
+        logger.error('Unexpected error in bring_flappy_judoka_to_front()', exception=e)
 
 
 # TODO: Might be useful in kano.utils


### PR DESCRIPTION
This is supposed to act as a safe guard when the Updater fails for whatever reason and FlappyJudoka was launched. Previously, several processes were killed in order to keep the game on top of the window. This is no longer needed and if the updater crashes, the OS will not be in an 'unstable' state anymore.

@tombettany @pazdera @convolu 