### PR TITLE
Deps: Bump kano-toolset dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends: debhelper (>= 9), build-essential, pkg-config, libgtk2.0-dev,
 
 Package: kano-updater
 Architecture: any
-Depends: ${misc:Depends}, kano-toolset (>= 2.1-2), python, libkdesk-dev,
+Depends: ${misc:Depends}, kano-toolset (>= 2.3.0-4), python, libkdesk-dev,
  gir1.2-gtk-3.0 (>= 3.10.2), kano-settings (>= 1.3-1), python-apt, schedtool,
  python-pip, kano-i18n
 Suggests: kano-profile


### PR DESCRIPTION
The PostUpdate scenarios require the use of `open_locked`'s `timeout`
parameter but if `kano-toolset` hasn't been updated to include this
feature before the Updater runs the cached version of the `kano.utils`
module is used and hence fails. Resolve this by bumping the dependency
requirement.

@Ealdwulf @pazdera @convolu do you think that this will fix the caching issue?