### PR TITLE
OS v2.4.0: Add fix for Bluez dependency issues

### DIFF
--- a/kano_updater/scenarios.py
+++ b/kano_updater/scenarios.py
@@ -210,7 +210,7 @@ class PreUpdate(Scenarios):
                 run_cmd_log('apt-get -y autoremove')
 
     def beta_230_to_beta_240(self):
-        pass
+        run_cmd_log('apt-get install bluez')
 
     # Not used at the moment: dev.kano.me > repo.kano.me
     def _migrate_repo_url(self):


### PR DESCRIPTION
When installing Bluez as a dependency of `kano-settings`, the
configuration can fail resulting in a broken update. Attempt to fix by
installing Bluez before anything else.