### PR TITLE
Separate update

### DIFF
--- a/bin/kano-updater
+++ b/bin/kano-updater
@@ -17,6 +17,8 @@ Usage:
   kano-updater set-scheduled (1|0)
   kano-updater first-boot
   kano-updater clean
+  kano-updater avail-ind-pkgs
+  kano-updater update-ind-pkg <package>
   kano-updater ui (relaunch-splash <parent-pid> | boot-window | shutdown-window)
   kano-updater [-f] [-n]
 
@@ -54,7 +56,7 @@ from kano.gtk3.kano_dialog import KanoDialog
 
 from kano_updater.os_version import TARGET_VERSION
 from kano_updater.commands.download import download
-from kano_updater.commands.install import install
+from kano_updater.commands.install import install, install_ind_package
 from kano_updater.commands.check import check_for_updates
 from kano_updater.commands.clean import clean
 from kano_updater.progress import CLIProgress, Relaunch
@@ -140,6 +142,11 @@ def run_install(gui=False, confirm=True, splash_pid=None):
         except Relaunch:
             clean_up()
             os.execvp('kano-updater', ['kano-updater', 'install'])
+
+
+def run_install_ind_pkg(package):
+    progress = CLIProgress()
+    install_ind_package(progress, package)
 
 
 def main():
@@ -234,6 +241,13 @@ def main():
 
             run_install(gui=args['--gui'], confirm=not args['--no-confirm'],
                         splash_pid=splash_pid)
+        elif args['update-ind-pkg']:
+            package = args['<package>']
+            run_install_ind_pkg(package)
+            
+        elif args['avail-ind-pkgs']:
+            print status.updatable_independent_packages
+            sys.exit(0)
         elif args['check']:
             if args['--interval']:
                 target_delta = float(args['<time>']) * 60 * 60

--- a/kano_updater/apt_wrapper.py
+++ b/kano_updater/apt_wrapper.py
@@ -17,7 +17,7 @@ from kano_updater.apt_progress_wrapper import AptDownloadProgress, \
 from kano_updater.os_version import SYSTEM_VERSION
 from kano_updater.progress import Phase
 import kano_updater.priority as Priority
-
+from kano_updater.special_packages import independent_install_list
 
 class AptWrapper(object):
     def __init__(self):
@@ -197,10 +197,20 @@ class AptWrapper(object):
 
         return True
 
+    def independent_packages_available(self, priority=Priority.STANDARD):
+        pkgs = []
+        for pkg in self._cache:
+            if pkg.name in independent_install_list:
+                if self._is_package_upgradable(pkg, priority=priority):
+                    pkgs.append(pkg.name)
+
+        return pkgs
+
     def is_update_available(self, priority=Priority.STANDARD):
         for pkg in self._cache:
-            if self._is_package_upgradable(pkg, priority=priority):
-                return True
+            if pkg.name not in independent_install_list:
+                if self._is_package_upgradable(pkg, priority=priority):
+                    return True
 
         return False
 

--- a/kano_updater/apt_wrapper.py
+++ b/kano_updater/apt_wrapper.py
@@ -197,7 +197,7 @@ class AptWrapper(object):
 
         return True
 
-    def is_update_avaliable(self, priority=Priority.STANDARD):
+    def is_update_available(self, priority=Priority.STANDARD):
         for pkg in self._cache:
             if self._is_package_upgradable(pkg, priority=priority):
                 return True

--- a/kano_updater/commands/check.py
+++ b/kano_updater/commands/check.py
@@ -106,13 +106,13 @@ def _do_check(progress, priority=Priority.NONE):
 
     if (
             priority <= Priority.URGENT
-            and apt_handle.is_update_avaliable(priority=Priority.URGENT)
+            and apt_handle.is_update_available(priority=Priority.URGENT)
         ):
         return Priority.URGENT
 
     if (
             priority <= Priority.STANDARD
-            and apt_handle.is_update_avaliable()
+            and apt_handle.is_update_available()
         ):
         return Priority.STANDARD
 

--- a/kano_updater/commands/check.py
+++ b/kano_updater/commands/check.py
@@ -88,6 +88,8 @@ def check_for_updates(progress=None, priority=Priority.NONE, is_gui=False):
     if priority <= Priority.STANDARD:
         status.last_check = int(time.time())
 
+    status.updatable_independent_packages = _get_ind_packages(priority)
+
     status.last_check_urgent = int(time.time())
 
     status.save()
@@ -117,3 +119,7 @@ def _do_check(progress, priority=Priority.NONE):
         return Priority.STANDARD
 
     return Priority.NONE
+
+def _get_ind_packages(priority=Priority.NONE):
+    return apt_handle.independent_packages_available(priority)
+    

--- a/kano_updater/commands/clean.py
+++ b/kano_updater/commands/clean.py
@@ -24,6 +24,8 @@ def clean(dry_run=False):
     elif status.state == UpdaterStatus.INSTALLING_UPDATES:
         # The installation was interrupted, go back one state
         status.state = UpdaterStatus.UPDATES_DOWNLOADED
+    elif status.state == UpdaterStatus.INSTALLING_INDEPENDENT:
+        status.state = UpdaterStatus.NO_UPDATES
     elif status.state == UpdaterStatus.UPDATES_INSTALLED:
         # Show a dialog and change the state back to no updates
         status.state = UpdaterStatus.NO_UPDATES

--- a/kano_updater/commands/install.py
+++ b/kano_updater/commands/install.py
@@ -147,6 +147,12 @@ def install_ind_package(progress, package):
         progress.abort(_(msg))
         return False
 
+    if package not in status.updatable_independent_packages:
+        msg = 'tried to install non-independent package {} using update_ind_pkg'.format(package)
+        logger.warn(msg)
+        progress.abort(_(msg))
+        return False        
+
     status.state = UpdaterStatus.INSTALLING_INDEPENDENT
     status.save()
 

--- a/kano_updater/special_packages.py
+++ b/kano_updater/special_packages.py
@@ -1,0 +1,9 @@
+#
+# special_packages.py
+#
+# Copyright (C) 2014-2015 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+# List of packages which require special treatment
+
+independent_install_list = ['kano-overworld']

--- a/kano_updater/status.py
+++ b/kano_updater/status.py
@@ -25,6 +25,7 @@ class UpdaterStatus(object):
     UPDATES_DOWNLOADED = 'updates-downloaded'
     INSTALLING_UPDATES = 'installing-updates'
     UPDATES_INSTALLED = 'updates-installed'
+    INSTALLING_INDEPENDENT = 'installing-independent'
 
     _status_file = STATUS_FILE_PATH
 
@@ -34,6 +35,7 @@ class UpdaterStatus(object):
         DOWNLOADING_UPDATES,
         UPDATES_DOWNLOADED,
         INSTALLING_UPDATES,
+        INSTALLING_INDEPENDENT,
         UPDATES_INSTALLED
     ]
 
@@ -56,6 +58,7 @@ class UpdaterStatus(object):
 
         self._state = self.NO_UPDATES
         self._last_check = 0
+        self._updatable_independent_packages = []
         self._last_check_urgent = 0
         self._last_update = 0
         self._first_boot_countdown = 0
@@ -94,6 +97,7 @@ class UpdaterStatus(object):
             self._state = data['state']
             self._last_update = data['last_update']
             self._last_check = data['last_check']
+            self._updatable_independent_packages = data.get('ind_pkg',[])
             self._last_check_urgent = data['last_check_urgent']
             self._first_boot_countdown = data['first_boot_countdown']
             self._is_urgent = (data['is_urgent'] == 1)
@@ -109,6 +113,7 @@ class UpdaterStatus(object):
             'state': self._state,
             'last_update': self._last_update,
             'last_check': self._last_check,
+            'ind_pkg': self._updatable_independent_packages,
             'last_check_urgent': self._last_check_urgent,
             'first_boot_countdown': self._first_boot_countdown,
             'is_urgent': 1 if self._is_urgent else 0,
@@ -176,6 +181,18 @@ class UpdaterStatus(object):
 
         logger.debug("Setting the status' last_check to: {}".format(value))
         self._last_check = value
+
+    @property
+    def updatable_independent_packages(self):
+        return self._updatable_independent_packages
+
+    @updatable_independent_packages.setter
+    def updatable_independent_packages(self, value):
+        if not isinstance(value, list) and all([isinstance(p, str) for p in value]):
+            msg = "'ind_pkg' must be a list of package names"
+            raise UpdaterStatusError(msg)
+        logger.debug("Setting the status' updatable_independent_packages to: {}".format(value))
+        self._updatable_independent_packages = value
 
     # -- is_urgent - flag used to distinguish between update priority levels
     @property


### PR DESCRIPTION
NB this isn't ready to merge, but I'd like people's opinion on whether this is the right approach to installing the package @tombettany @alex5imon @skarbat @radujipa 

This PR:
* Adds a list of packages in 'special_packages.py' which don't trigger an OS update.
*  Introduces a new updater command 'kano-updater update_ind_pkg <pkg>'. This enters a new state  'INSTALLING_INDEPENDENT'  and installs the package, then transitions to UPDATES_INSTALLED. The updater is prevented from going into install mode when an independent package is being installed and vice versa.
* Adds a new command 'avail_ind_pkgs' which lists the spcial packages which are available to be updated. This may be removed if we decide on a different way of communicating with kano-dashboard.

Questions:
* is UPDATES_INSTALLED the correct state after 'INSTALLING_INDEPENDENT'? I'm not quite sure what effect it has.
* Is the progress object relevent to update_ind_pkg?