### PR TITLE
Update status.updatable_independent_packages after installing an update

### DIFF
--- a/kano_updater/apt_wrapper.py
+++ b/kano_updater/apt_wrapper.py
@@ -208,7 +208,8 @@ class AptWrapper(object):
 
     def is_update_available(self, priority=Priority.STANDARD):
         for pkg in self._cache:
-            if pkg.name not in independent_install_list:
+            # exclude independent packages, UNLESS this is an urgent update
+            if priority == Priority.URGENT or pkg.name not in independent_install_list:
                 if self._is_package_upgradable(pkg, priority=priority):
                     return True
 

--- a/kano_updater/commands/check.py
+++ b/kano_updater/commands/check.py
@@ -88,7 +88,9 @@ def check_for_updates(progress=None, priority=Priority.NONE, is_gui=False):
     if priority <= Priority.STANDARD:
         status.last_check = int(time.time())
 
-    status.updatable_independent_packages = _get_ind_packages(priority)
+    # always check independent packages as NONE as urgent updates to
+    # these packages are dealt with by the main updater
+    status.updatable_independent_packages = get_ind_packages(Priority.NONE)
 
     status.last_check_urgent = int(time.time())
 
@@ -120,6 +122,6 @@ def _do_check(progress, priority=Priority.NONE):
 
     return Priority.NONE
 
-def _get_ind_packages(priority=Priority.NONE):
+def get_ind_packages(priority=Priority.NONE):
     return apt_handle.independent_packages_available(priority)
     

--- a/kano_updater/commands/clean.py
+++ b/kano_updater/commands/clean.py
@@ -25,6 +25,7 @@ def clean(dry_run=False):
         # The installation was interrupted, go back one state
         status.state = UpdaterStatus.UPDATES_DOWNLOADED
     elif status.state == UpdaterStatus.INSTALLING_INDEPENDENT:
+        # The installation was interrupted, go back one state
         status.state = UpdaterStatus.NO_UPDATES
     elif status.state == UpdaterStatus.UPDATES_INSTALLED:
         # Show a dialog and change the state back to no updates

--- a/kano_updater/commands/install.py
+++ b/kano_updater/commands/install.py
@@ -142,7 +142,12 @@ def install_ind_package(progress, package):
     status = UpdaterStatus.get_instance()
     # install an independent package.
 
-    if status.state == UpdaterStatus.INSTALLING_UPDATES:
+    previous_state = status.state
+
+    # Allow installing only if the updater is in certain safe states.
+    if status.state not in [UpdaterStatus.NO_UPDATES,
+                            UpdaterStatus.UPDATES_AVAILABLE,
+                            UpdaterStatus.UPDATES_INSTALLED]:
         msg = 'The install is already running'
         logger.warn(msg)
         progress.abort(_(msg))
@@ -159,7 +164,7 @@ def install_ind_package(progress, package):
 
     apt_handle.upgrade(package, progress)
 
-    status.state = UpdaterStatus.UPDATES_INSTALLED
+    status.state = previous_state
     status.last_update = int(time.time())
 
     # always check independent packages as NONE as urgent updates to

--- a/kano_updater/commands/install.py
+++ b/kano_updater/commands/install.py
@@ -23,6 +23,7 @@ from kano_updater.auxiliary_tasks import run_aux_tasks
 from kano_updater.progress import DummyProgress, Phase, Relaunch
 from kano_updater.utils import run_pip_command
 from kano_updater.commands.download import download
+from kano_updater.commands.check import get_ind_packages
 import kano_updater.priority as Priority
 
 
@@ -160,6 +161,10 @@ def install_ind_package(progress, package):
 
     status.state = UpdaterStatus.UPDATES_INSTALLED
     status.last_update = int(time.time())
+
+    # always check independent packages as NONE as urgent updates to
+    # these packages are dealt with by the main updater
+    status.updatable_independent_packages = get_ind_packages(Priority.NONE)
     status.is_scheduled = False
     status.save()
 


### PR DESCRIPTION
This PR fixes a problem noticed by @tombettany in that the status file wasn't being updated after installing an independent package, thus causing the gui to think it could still be installed.

While looking at this I noticed that because the list of updatable independent packages is made using whatever priority level the check command is called  with, that field in the status file coudl flip flop between having and not having the package.  Therefore I have looked through the use of priority and made a couple of changes:

Generally, only deal with independent packages *independently* at ordinary priority . At URGENT priority,  treat them the same as other packages (IE< if an urgent update is pushed to an 'idependent' package, this is installed using the urgent update facility).
Detail:
* Always make the list of updatable independent packages using Priority.NONE
* When checking for urgent updates, don't exclude independent packages.
@radujipa @tombettany 