### PR TITLE
Fixed Jessie urgent updates into APT during an update

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-updater (2.5.0-1) unstable; urgency=low
+
+  * Fixed urgent updates for Jessie users
+
+ -- Team Kano <dev@kano.me>  Mon, 11 Apr 2016 18:04:00 +0100
+
 kano-updater (2.4.0-1) unstable; urgency=low
 
   * Improved Flappy Judoka game launching

--- a/debian/postinst
+++ b/debian/postinst
@@ -35,10 +35,15 @@ case "$1" in
 
         pip install --upgrade $PIP_DEPENDENCIES
 
-        # Add the urgent repo to sources - if not already existent
+        # Add the urgent repo to sources - if not already existent (jessie users)
+        grep -q 'release-urgent' $KANO_SOURCES || \
+            grep -m 1 '^deb http://.*.kano.me/archive-jessie/' $KANO_SOURCES | \
+                sed -r "s|^deb http://([a-z]*).kano.me.*$|deb http://\1.kano.me/archive-jessie/ release-urgent main|" >> $KANO_SOURCES
+
+        # Add the urgent repo to sources - if not already existent (wheezy users)
         grep -q 'release-urgent' $KANO_SOURCES || \
             grep -m 1 '^deb http://.*.kano.me/archive/' $KANO_SOURCES | \
-            sed -r "s|^deb http://([a-z]*).kano.me.*$|deb http://\1.kano.me/archive release-urgent main|" >> $KANO_SOURCES
+                sed -r "s|^deb http://([a-z]*).kano.me.*$|deb http://\1.kano.me/archive/ release-urgent main|" >> $KANO_SOURCES
 
         ;;
 esac


### PR DESCRIPTION
 * On Jessie, the APT url was not being updated, so no urgent updates were possible.
 * Wheezy users should also get the urgent updates (not strictly necessary though, I think).

@Ealdwulf 
