### PR TITLE
Speed up kano-updater ui boot-window

### DIFF
--- a/bin/kano-updater
+++ b/bin/kano-updater
@@ -188,6 +188,10 @@ def main():
             from kano_updater.ui.main import launch_relaunch_countdown_gui
             launch_relaunch_countdown_gui(int(args['<parent-pid>']))
         elif args['boot-window']:
+
+            # Note that this code is gate by kano-updater-quickcheck,
+            # so additional cases must be inserted there too.
+
             status = UpdaterStatus.get_instance()
             status.is_shutdown = False
             status.save()

--- a/bin/kano-updater-quickcheck
+++ b/bin/kano-updater-quickcheck
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# kano-updater-quickcheck
+#
+# Copyright (C) 2015 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+
+STATUS_FILE=/var/cache/kano-updater/status.json
+
+# check if we need to run 
+DO_RUN=$(jq '.is_scheduled!=0 or .state!="no-updates"' $STATUS_FILE)
+
+if [ "$DO_RUN" == "true" ] ; then
+    /usr/bin/kano-updater ui boot-window
+fi

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-updater (3.0.0-1) unstable; urgency=low
+
+  * Add kano-updater-quickcheck command
+
+ -- Team Kano <dev@kano.me>  Mon, 11 Apr 2016 18:04:00 +0100
+
 kano-updater (2.5.0-1) unstable; urgency=low
 
   * Fixed urgent updates for Jessie users

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Package: kano-updater
 Architecture: any
 Depends: ${misc:Depends}, kano-toolset (>= 2.4.0-1), python, libkdesk-dev,
  gir1.2-gtk-3.0 (>= 3.10.2), kano-settings (>= 1.3-1), python-apt, schedtool,
- python-pip, kano-i18n
+ python-pip, kano-i18n, jq
 Suggests: kano-profile
 Description: Tool to update Kanux
  A tool written in Python to upgrade Debian packages, upgrade Python modules and extend filesystem.

--- a/debian/postinst
+++ b/debian/postinst
@@ -17,6 +17,7 @@ case "$1" in
 
         # Create custom sudoers file
         echo "%sudo   ALL=(root) NOPASSWD: /usr/bin/kano-updater" > $TMP_FILE
+        echo "%sudo   ALL=(root) NOPASSWD: /usr/bin/kano-updater-quickcheck" >> $TMP_FILE
         echo "%sudo   ALL=(root) NOPASSWD: /usr/bin/expand-rootfs" >> $TMP_FILE
 
         # The owner and group for the sudoers file must both be 0


### PR DESCRIPTION
This PR adds fast script for querying updater status file and running kano-updater if necessary.
A dependency on jq (json query) is introduced.

@tombettany @skarbat @alex5imon  
Note that there is some maintenance cost to this as extra triggers must be added in both places.
For https://github.com/KanoComputing/peldins/issues/2327
