### PR TITLE
Add fix to set `dtparam=audio=on` in /boot/config.txt

### DIFF
--- a/kano_updater/scenarios.py
+++ b/kano_updater/scenarios.py
@@ -466,4 +466,13 @@ class PostUpdate(Scenarios):
         pass
 
     def beta_240_to_beta_300(self):
-        pass
+        def enable_audio_device():
+            from kano_settings.boot_config import set_config_value
+            set_config_value("dtparam=audio", "on")
+            try:
+                from kano_settings.boot_config import end_config_transaction
+                end_config_transaction()
+            except ImportError:
+                logger.error("end_config_transaciton not present - update to kano-settings failed?")
+        enable_audio_device()
+


### PR DESCRIPTION
This should add the setting from https://github.com/KanoComputing/kano-settings/pull/369 for users who update.
Function copied from spi modification in 2.3.0 scenario.
@alex5imon @skarbat 