### PR TITLE
Independent Pkgs: Update the sources before installing

### DIFF
--- a/kano_updater/commands/install.py
+++ b/kano_updater/commands/install.py
@@ -162,11 +162,30 @@ def install_ind_package(progress, package):
         msg = 'tried to install non-independent package {} using update_ind_pkg'.format(package)
         logger.warn(msg)
         progress.abort(_(msg))
-        return False        
+        return False
 
     status.state = UpdaterStatus.INSTALLING_INDEPENDENT
     status.save()
 
+    update_sources_phase = 'updating-sources'
+    installing_idp_phase = 'installing-idp-package'
+    progress.split(
+        Phase(
+            update_sources_phase,
+            _('Updating apt sources'),
+            10
+        ),
+        Phase(
+            installing_idp_phase,
+            _('Installing independent package'),
+            90
+        )
+    )
+
+    progress.start(update_sources_phase)
+    apt_handle.update(progress)
+
+    progress.start(installing_idp_phase)
     apt_handle.upgrade(package, progress)
 
     status.state = previous_state

--- a/kano_updater/progress.py
+++ b/kano_updater/progress.py
@@ -20,6 +20,19 @@ class Relaunch(Exception):
 
 
 class Phase(object):
+    '''
+    A single task
+
+    :param name: The identifier for the phase
+    :param label: The human readable label for the phase
+    :param weight: Metric for task size. Often used as percentage of the whole
+    :param is_main: Should subtasks be labelled as belonging to this task
+    :type name: str
+    :type label: str
+    :type weight: int or float
+    :type is_main: bool
+    '''
+
     def __init__(self, name, label, weight=1, is_main=False):
         self.name = name
         self.label = label


### PR DESCRIPTION
KanoComputing/peldins#2375
When installing the independent updates, it is possible for the source
repositories to have changed in the time between the package being
identified as having updates available and the user actually choosing to
update it. Resolve this problem by updating the APT sources immediately
before attempting to update the package.

cc @Ealdwulf @pazdera 