### PR TITLE
Bluez: Move bluez preinstall to happen with every update

### DIFF
--- a/kano_updater/scenarios.py
+++ b/kano_updater/scenarios.py
@@ -250,8 +250,7 @@ class PreUpdate(Scenarios):
     def _finalise(self):
         # When bluez is installed through a dependency it fails to configure
         # Get around this by installing it first
-        run_cmd_log('apt-get install bluez')
-
+        run_cmd_log('apt-get -y install bluez')
 
     # Not used at the moment: dev.kano.me > repo.kano.me
     def _migrate_repo_url(self):
@@ -581,4 +580,6 @@ class PostUpdate(Scenarios):
         disable_audio_dither()
 
     def beta_330_to_beta_340(self):
-        pass
+        # fix locale database if it was
+        # corrupted by the NOOBS file hole problem
+        run_cmd_log('locale-gen')

--- a/kano_updater/scenarios.py
+++ b/kano_updater/scenarios.py
@@ -79,6 +79,11 @@ class Scenarios(object):
                 update_failed(msg)
                 raise Exception(msg)
 
+        self._finalise()
+
+    def _finalise(self):
+        pass
+
 
 class PreUpdate(Scenarios):
     _type = "pre"
@@ -225,7 +230,7 @@ class PreUpdate(Scenarios):
                 run_cmd_log('apt-get -y autoremove')
 
     def beta_230_to_beta_240(self):
-        run_cmd_log('apt-get install bluez')
+        pass
 
     def beta_240_to_beta_300(self):
         pass
@@ -241,6 +246,12 @@ class PreUpdate(Scenarios):
 
     def beta_330_to_beta_340(self):
         pass
+
+    def _finalise(self):
+        # When bluez is installed through a dependency it fails to configure
+        # Get around this by installing it first
+        run_cmd_log('apt-get install bluez')
+
 
     # Not used at the moment: dev.kano.me > repo.kano.me
     def _migrate_repo_url(self):


### PR DESCRIPTION
https://trello.com/c/1QrdXt2l/92-updater-pi2-update-from-2-4-0-to-3-4-0-failed
The update of `bluez` will often fail due to its postinstall
configuration script exiting with error status when the user does not
have a bluetooth capable device present. A work-around to this was
utilised for the update from v2.3.0 - v2.4.0 via a preupdate scenario
which installed the package manually. Unfortunately, this same problem
affects users updating from v2.4.0 to later versions so make the
solution more broad to do the install independently for every update.

This has a side-effect of adding a function where pre- and post-update
scripts which should run on every update can be located.

cc @Ealdwulf @radujipa @skarbat 