### PR TITLE
Fixes for lost automatic login after upgrade

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Section: admin
 Priority: optional
 Standards-Version: 3.9.2
 Build-Depends: debhelper (>= 9), build-essential, pkg-config, libgtk2.0-dev,
-               lxpanel (>= 0.7.0), libfm-dev, libkdesk-dev, gettext
+               lxpanel (>= 0.7.0), libfm-dev, libkdesk-dev, gettext, kano-init
 
 Package: kano-updater
 Architecture: any

--- a/kano_updater/scenarios.py
+++ b/kano_updater/scenarios.py
@@ -678,4 +678,4 @@ class PostUpdate(Scenarios):
             run_cmd_log('kano-apps install --no-gui {app}'.format(app=app))
 
         # Tell kano-init to put the automatic logins up-to-date
-        reconfigure_autostart_policy
+        reconfigure_autostart_policy()

--- a/kano_updater/scenarios.py
+++ b/kano_updater/scenarios.py
@@ -14,6 +14,7 @@ from kano_updater.utils import install, remove_user_files, update_failed, \
     purge, rclocal_executable, migrate_repository, get_users, run_for_every_user
 from kano.utils import run_cmd_log, get_user_unsudoed, write_file_contents, \
     is_installed
+from kano_init.utils import reconfigure_autostart_policy
 
 
 class Scenarios(object):
@@ -675,3 +676,6 @@ class PostUpdate(Scenarios):
 
         for app in new_apps:
             run_cmd_log('kano-apps install --no-gui {app}'.format(app=app))
+
+        # Tell kano-init to put the automatic logins up-to-date
+        reconfigure_autostart_policy


### PR DESCRIPTION
This change should fix the automatic tty login being lost, after upgrading from several older OS versions.

@tombettany @Ealdwulf 
