### PR TITLE
Correctly enable Overture during an upgrade

### DIFF
--- a/kano_updater/scenarios.py
+++ b/kano_updater/scenarios.py
@@ -288,7 +288,8 @@ class PreUpdate(Scenarios):
         pass
 
     def beta_390_to_beta_3100(self):
-        pass
+        # The new Overture onboarding needs to be enabled - disabling old tty-based kano-init
+        run_cmd_log('kano-init finalise --force')
 
     def _finalise(self):
         # When bluez is installed through a dependency it fails to configure


### PR DESCRIPTION
This change applies the new systemd style in kano-init during an upgrade.
The side effect was that Overture was being launched on top of Dashboard.

Sorry, it will probably clash with: https://github.com/KanoComputing/kano-updater/pull/226

@radujipa @tombettany 
