### PR TITLE
Fix overture kicking in after an upgrade

### DIFF
--- a/kano_updater/scenarios.py
+++ b/kano_updater/scenarios.py
@@ -593,6 +593,9 @@ class PostUpdate(Scenarios):
         # tell dashboard to skip Overworld and kit setup onboarding phase
         run_for_every_user('touch ~/.dashboard-click-onboarding-done')
 
+        # tell kano-init to setup to kit to go Dashboard the systemd way
+        run_cmd_log('kano-init finalise --force')
+
     def beta_300_to_beta_310(self):
         pass
 

--- a/kano_updater/scenarios.py
+++ b/kano_updater/scenarios.py
@@ -592,9 +592,6 @@ class PostUpdate(Scenarios):
         # tell dashboard to skip Overworld and kit setup onboarding phase
         run_for_every_user('touch ~/.dashboard-click-onboarding-done')
 
-        # tell kano-init to setup to kit to go Dashboard the systemd way
-        run_cmd_log('kano-init finalise --force')
-
     def beta_300_to_beta_310(self):
         pass
 

--- a/kano_updater/scenarios.py
+++ b/kano_updater/scenarios.py
@@ -288,8 +288,7 @@ class PreUpdate(Scenarios):
         pass
 
     def beta_390_to_beta_3100(self):
-        # The new Overture onboarding needs to be enabled - disabling old tty-based kano-init
-        run_cmd_log('kano-init finalise --force')
+        pass
 
     def _finalise(self):
         # When bluez is installed through a dependency it fails to configure
@@ -706,4 +705,6 @@ class PostUpdate(Scenarios):
         pass
 
     def beta_390_to_beta_3100(self):
+        # The new Overture onboarding needs to be enabled - disabling old tty-based kano-init
+        run_cmd_log('kano-init finalise --force')
         install('kano2-app')


### PR DESCRIPTION
After an upgrade from 2.4.0, kano-init drags the overture app package,
which starts in multi-user mode. This mistakenly goes through the onboarding on reboot.
We did not care too much about this systemd mode previously.

Fixed by forcing kano-init to prepare the system for a regular graphics mode Dashboard bootup.

@tombettany @radujipa 