### PR TITLE
Provide a --dry-run option to query udpates availability

### DIFF
--- a/bin/kano-updater-quickcheck
+++ b/bin/kano-updater-quickcheck
@@ -1,3 +1,6 @@
+#!/bin/bash
+#
+# kano-updater-quickcheck
 #
 # Copyright (C) 2015 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2

--- a/bin/kano-updater-quickcheck
+++ b/bin/kano-updater-quickcheck
@@ -1,16 +1,28 @@
-#!/bin/bash
-#
-# kano-updater-quickcheck
 #
 # Copyright (C) 2015 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 #
+# Runs the updater in boot-window mode, if upgrades are avaiable.
+# Pass "--dry-run" to simply get an errorcode indication, 1 means updates are available.
+#
 
 STATUS_FILE=/var/cache/kano-updater/status.json
+dry_run=$1
 
-# check if we need to run 
-DO_RUN=$(jq '.is_scheduled!=0 or .state!="no-updates"' $STATUS_FILE)
+function are_updates_available()
+{
+    # check if we need to run
+    DO_RUN=$(jq '.is_scheduled!=0 or .state!="no-updates"' $STATUS_FILE)
+    if [ "$DO_RUN" == "true" ]; then
+        return 1
+    fi
+}
 
-if [ "$DO_RUN" == "true" ] ; then
-    /usr/bin/kano-updater ui boot-window
+are_updates_available
+if [ $? == 1 ]; then
+   if [ "$dry_run" == "--dry-run" ]; then
+       exit 1
+   else
+       echo "/usr/bin/kano-updater ui boot-window"
+   fi
 fi

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-updater (3.10.1-0) unstable; urgency=low
+
+  * Added dry-run to kano-updarer-quickcheck
+
+ -- Team Kano <dev@kano.me>  Fri, 26 May 2017 12:08:00 +0100
+
 kano-updater (3.10.0-1) unstable; urgency=low
 
   * Bump version


### PR DESCRIPTION
Complements this PR: https://github.com/KanoComputing/os-dashboard/pull/329
