### PR TITLE
Version: Bump to 3.9.1-Lovelace

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -35,6 +35,12 @@ kano-updater (3.10.0-1) unstable; urgency=low
 
  -- Team Kano <dev@kano.me>  Tue, 21 Mar 2017 15:52:00 +0000
 
+kano-updater (3.9.1-1) unstable; urgency=low
+
+  * Bump version
+
+ -- Team Kano <dev@kano.me>  Wed, 19 Jul 2017 16:50:00 +0000
+
 kano-updater (3.9.0-1) unstable; urgency=low
 
   * Bump version

--- a/kano_updater/scenarios.py
+++ b/kano_updater/scenarios.py
@@ -182,14 +182,17 @@ class PreUpdate(Scenarios):
         self.add_scenario("Kanux-Beta-3.8.0", "Kanux-Beta-3.9.0-Lovelace",
                           self.beta_380_to_beta_390)
 
-        self.add_scenario("Kanux-Beta-3.9.0-Lovelace", "Kanux-Beta-3.10.0-Lovelace",
-                          self.beta_390_to_beta_3100)
+        self.add_scenario("Kanux-Beta-3.9.0-Lovelace", "Kanux-Beta-3.9.1-Lovelace",
+                          self.beta_3_9_0_to_beta_3_9_1)
+
+        self.add_scenario("Kanux-Beta-3.9.1-Lovelace", "Kanux-Beta-3.10.0-Lovelace",
+                          self.beta_3_9_1_to_beta_3_10_0)
 
         self.add_scenario("Kanux-Beta-3.10.0-Lovelace", "Kanux-Beta-3.10.1-Lovelace",
-                          self.beta_3100_to_beta_3101)
+                          self.beta_3_10_0_to_beta_3_10_1)
 
         self.add_scenario("Kanux-Beta-3.10.1-Lovelace", "Kanux-Beta-3.10.2-Lovelace",
-                          self.beta_3101_to_beta_3102)
+                          self.beta_3_10_1_to_beta_3_10_2)
 
         self.add_scenario("Kanux-Beta-3.10.2-Lovelace", "Kanux-Beta-3.10.3-Lovelace",
                           self.beta_3_10_2_to_beta_3_10_3)
@@ -303,13 +306,16 @@ class PreUpdate(Scenarios):
     def beta_380_to_beta_390(self):
         pass
 
-    def beta_390_to_beta_3100(self):
+    def beta_3_9_0_to_beta_3_9_1(self):
         pass
 
-    def beta_3100_to_beta_3101(self):
+    def beta_3_9_1_to_beta_3_10_0(self):
         pass
 
-    def beta_3101_to_beta_3102(self):
+    def beta_3_10_0_to_beta_3_10_1(self):
+        pass
+
+    def beta_3_10_1_to_beta_3_10_2(self):
         pass
 
     def beta_3_10_2_to_beta_3_10_3(self):
@@ -421,14 +427,17 @@ class PostUpdate(Scenarios):
         self.add_scenario("Kanux-Beta-3.8.0", "Kanux-Beta-3.9.0-Lovelace",
                           self.beta_380_to_beta_390)
 
-        self.add_scenario("Kanux-Beta-3.9.0-Lovelace", "Kanux-Beta-3.10.0-Lovelace",
-                          self.beta_390_to_beta_3100)
+        self.add_scenario("Kanux-Beta-3.9.0-Lovelace", "Kanux-Beta-3.9.1-Lovelace",
+                          self.beta_3_9_0_to_beta_3_9_1)
+
+        self.add_scenario("Kanux-Beta-3.9.1-Lovelace", "Kanux-Beta-3.10.0-Lovelace",
+                          self.beta_3_9_1_to_beta_3_10_0)
 
         self.add_scenario("Kanux-Beta-3.10.0-Lovelace", "Kanux-Beta-3.10.1-Lovelace",
-                          self.beta_3100_to_beta_3101)
+                          self.beta_3_10_0_to_beta_3_10_1)
 
         self.add_scenario("Kanux-Beta-3.10.1-Lovelace", "Kanux-Beta-3.10.2-Lovelace",
-                          self.beta_3101_to_beta_3102)
+                          self.beta_3_10_1_to_beta_3_10_2)
 
         self.add_scenario("Kanux-Beta-3.10.2-Lovelace", "Kanux-Beta-3.10.3-Lovelace",
                           self.beta_3_10_2_to_beta_3_10_3)
@@ -741,17 +750,20 @@ class PostUpdate(Scenarios):
     def beta_380_to_beta_390(self):
         pass
 
-    def beta_390_to_beta_3100(self):
+    def beta_3_9_0_to_beta_3_9_1(self):
+        pass
+
+    def beta_3_9_1_to_beta_3_10_0(self):
         # The new Overture onboarding needs to be enabled - disabling old tty-based kano-init
         run_cmd_log('kano-init finalise --force')
 
         # Install the kano-os metapackage for top level OS packages.
         install('kano-os')
 
-    def beta_3100_to_beta_3101(self):
+    def beta_3_10_0_to_beta_3_10_1(self):
         pass
 
-    def beta_3101_to_beta_3102(self):
+    def beta_3_10_1_to_beta_3_10_2(self):
         pass
 
     def beta_3_10_2_to_beta_3_10_3(self):

--- a/kano_updater/version.py
+++ b/kano_updater/version.py
@@ -1,6 +1,6 @@
 # version.py
 #
-# Copyright (C) 2015-2016 Kano Computing Ltd.
+# Copyright (C) 2015-2017 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 #
 # The version of the updater


### PR DESCRIPTION
Bump version for next release.

Needed in `master` regardless of the image generation approach.