### PR TITLE
Removed local ALSA config files from all users

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,9 @@
 kano-updater (3.12.0-0) unstable; urgency=low
 
   * Bump version for Kanux Beta v3.12.0
+  * Removed local ALSA config files from all users
 
- -- Team Kano <dev@kano.me>  Mon, 4 Sep 2017 11:20:00 +0100
+ -- Team Kano <dev@kano.me>  Fri, 8 Sep 2017 10:48:00 +0100
 
 kano-updater (3.11.0-0) unstable; urgency=low
 

--- a/kano_updater/scenarios.py
+++ b/kano_updater/scenarios.py
@@ -847,4 +847,5 @@ class PostUpdate(Scenarios):
             logger.error("failed to update config")
 
     def beta_3_11_0_to_beta_3_12_0(self):
-        pass
+        # Remove .asoundrc files from all users (see kano-desktop & kano-settings).
+        remove_user_files(['.asoundrc'])


### PR DESCRIPTION
This change in a post-update from 3.11.0 to 3.12.0 is to ensure
that the local ALSA config files are removed such that only the
system ones are kept (see kano-settings, kano-desktop).