### PR TITLE
WIP Detach tty

### DIFF
--- a/bin/kano-updater-internal
+++ b/bin/kano-updater-internal
@@ -65,7 +65,8 @@ from kano_updater.progress import CLIProgress, Relaunch
 from kano_updater.status import UpdaterStatus
 from kano_updater.utils import make_low_prio, is_running, \
     remove_pid_file, pause_notifications, resume_notifications, show_kano_dialog, \
-    run_bg, enable_power_button, disable_power_button, verify_kit_is_plugged
+    run_bg, enable_power_button, disable_power_button, verify_kit_is_plugged, \
+    detach_from_tty
 from kano_updater.return_codes import RC, RCState
 import kano_updater.priority as Priority
 
@@ -174,6 +175,9 @@ def main():
 
     msg = _('Administrator priviledges are required to perform this operation')
     enforce_root(u"{}: {}".format(_('ERROR'), msg))
+
+    # detach from tty to avoid packages trying to run interactive commands
+    detach_from_tty()
 
     args = docopt.docopt(__doc__, version=str(get_target_version()))
     _g_gui_mode = args['--gui']

--- a/kano_updater/utils.py
+++ b/kano_updater/utils.py
@@ -15,6 +15,8 @@ import grp
 import signal
 import re
 import subprocess
+import fcntl
+import termios
 
 from kano.logging import logger
 from kano.utils.shell import run_cmd, run_bg, run_cmd_log
@@ -577,3 +579,15 @@ def verify_kit_is_plugged():
             ).run()
 
     return is_plugged and not is_battery_
+
+
+def detach_from_tty():
+    """
+    Detach from controlling tty
+    """
+    try:
+        myTTY = os.open("/dev/tty",os.O_RDWR)
+        fcntl.ioctl(myTTY, termios.TIOCNOTTY, 0)
+        os.close(myTTY)
+    except:
+        logger.error("Failed to close controlling terminal")


### PR DESCRIPTION
Before I forget, I think this could make the updater slightly more immune to packages asking interactive questions.
NOT proposing to merge for this rc, we've done enough to the updater already.

This PR:
 -  causes the updater to detach from its controlling terminal ( if any) tty to prevent any packages thinking they have interactive input.
