### PR TITLE
Disable newer audio driver with audio_pwm_mode=1 in config.txt

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,8 +3,9 @@ kano-updater (4.0.0-0) unstable; urgency=low
   * Bump version for Kano OS v4.0.0 "Hopper"
   * Fix GTK compatibility for Stretch release
   * Add support for CKT
+  * Disable newer audio driver with audio_pwm_mode=1 in config.txt
 
- -- Team Kano <dev@kano.me>  Thu, 23 Apr 2018 11:48:00 +0100
+ -- Team Kano <dev@kano.me>  Fri, 22 Jun 2018 11:48:00 +0100
 
 kano-updater (3.15.0-0) unstable; urgency=low
 

--- a/kano_updater/scenarios.py
+++ b/kano_updater/scenarios.py
@@ -973,8 +973,9 @@ class PostUpdate(Scenarios):
             if c['rpi-chromium-mods-kano'].installed >= '20170809':
                 install('scratch2')
             else:
-                logger.error("beta_3_13_0_to_beta_3_14_0: wrong version of rpi-chromium-mods-kano installed: {}".format(
-                             c['rpi-chromium-mods-kano'].installed.version)
+                logger.error(
+                    "beta_3_13_0_to_beta_3_14_0: wrong version of rpi-chromium-mods-kano installed: {}"
+                    .format(c['rpi-chromium-mods-kano'].installed.version)
                 )
         except Exception as e:
             logger.error("beta_3_13_0_to_beta_3_14_0: Failed to install scratch2", exception=e)
@@ -986,4 +987,15 @@ class PostUpdate(Scenarios):
         pass
 
     def beta_3_15_0_to_beta_4_0_0(self):
-        pass
+        try:
+            from textwrap import dedent
+            extra_config = dedent("""
+            # Disable the new audio pwm driver to avoid the risk of a kernel / firmware crash.
+            # https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=195178
+            # https://github.com/raspberrypi/linux/issues/2587
+            audio_pwm_mode=1
+            """)
+            self._add_boot_config_options(extra_config)
+
+        except Exception as e:
+            logger.error("Failed to update config: {}".format(e))


### PR DESCRIPTION
This post-update scenario matches the config in the default
config.txt file provided by kano-settings.

Matches https://github.com/KanoComputing/kano-settings/pull/511