### PR TITLE
COPPA: Set the parental setting in the background

### DIFF
--- a/kano_updater/scenarios.py
+++ b/kano_updater/scenarios.py
@@ -7,6 +7,7 @@
 
 import os
 import shutil
+import time
 import traceback
 
 from kano.logging import logger
@@ -1269,4 +1270,11 @@ class PostUpdate(Scenarios):
         run_cmd_log('rm -f /usr/share/icons/Kano/66x66/apps/pidgin.png')
 
         # Set Parental Controls to Ultimate for all existing users. COPPA.
-        run_for_every_user('sudo kano-settings-cli set parental --level=3 "kano"')
+        # FIXME: The parental command sets the parental level and then
+        #        restarts the sentry server, blocking on the process. We kick
+        #        it off in the background here and wait a bit for things to
+        #        happen but the settings command shouldn't block
+        run_for_every_user(
+            'sudo kano-settings-cli set parental --level=3 "kano" &'
+        )
+        time.sleep(10)


### PR DESCRIPTION
During the post-update scenarios the parental setting is set to be COPPA
compliant. When we do this, the `kano-settings-cli` command it used but
this blocks while the sentry proxy server is restarted and then owns the
server itself and thus never returns, causing a hang. To resolve this,
trigger the parental setting configuration in the background and wait
for the process to establish itself.